### PR TITLE
deploy: id-token 권한을 write으로 추가

### DIFF
--- a/.github/workflows/packy-cd.yml
+++ b/.github/workflows/packy-cd.yml
@@ -6,6 +6,7 @@ on:
       - develop
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:


### PR DESCRIPTION
## 🛰️ Issue Number
#12 

## 🪐 작업 내용
AWS Access key와 Secret key 대신 OIDC를 적용한 Role을 사용하기 위해 id-token 권한을 write으로 추가해주었습니다.

## 📚 Reference
- https://velog.io/@jeongmin78/CICD-Github-Action-AWS-IAM-Role-%EC%9D%B4%EC%9A%A9%ED%95%B4-%EC%9D%B4%EB%AF%B8%EC%A7%80%EB%A5%BC-ECR%EC%97%90-%EC%98%AC%EB%A6%AC%EA%B8%B0-8n3fmmgn
- https://stackoverflow.com/questions/72183048/what-is-the-permission-scope-of-id-token-in-github-action

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
