### PR TITLE
deploy: ECR에 image push하는 스크립트 수정

### DIFF
--- a/.github/workflows/packy-cd.yml
+++ b/.github/workflows/packy-cd.yml
@@ -6,7 +6,6 @@ on:
       - develop
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
@@ -21,9 +20,9 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
-          role-session-name: GitHubActions
-          role-to-assume: ${{ secrets.ROLE_ARN }}
 
       - name: Login to Amazon ECR
         id: login-ecr


### PR DESCRIPTION
## 🛰️ Issue Number
#12 

## 🪐 작업 내용
CD 스크립트를 작성하며 AWS credentials에 접근하기 위해 OIDC를 사용하고자 하였으나 권한 문제가 발생하여 Access key를 사용하는 방법으로 스크립트를 수정했습니다.

## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
