### PR TITLE
deploy: CD 스크립트 문법 오류 수정

### DIFF
--- a/.github/workflows/packy-cd.yml
+++ b/.github/workflows/packy-cd.yml
@@ -57,11 +57,11 @@ jobs:
       - name: Beanstalk Deploy
         uses: einaregilsson/beanstalk-deploy@v14
         with:
-          aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_access_key: ${{ secrets.AWS_ACCESS_KEY }}
           aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           application_name: packy-dev-beanstalk
           environment_name: Packy-dev-beanstalk-env
-          version_label: earth-docker-${{steps.current-time.outputs.formattedTime}}
-          region: ap-northeast-2
+          version_label: packy-dev-${{steps.current-time.outputs.formattedTime}}
+          region: ${{ secrets.AWS_REGION }}
           deployment_package: deploy/deploy.zip
           wait_for_environment_recovery: 200


### PR DESCRIPTION
## 🛰️ Issue Number
#12 

## 🪐 작업 내용
CD 스크립트에서 아래와 같은 부분을 수정했습니다.
- secrets 값과 version_label 잘못 적힌 것을 수정했습니다.
- 동일한 값인 AWS Region을 secrets으로 공통으로 관리하도록 했습니다.

## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
