### PR TITLE
deploy: 이미지 아키텍처를 amd64로 변경

### DIFF
--- a/packy-api/profile-dev.gradle
+++ b/packy-api/profile-dev.gradle
@@ -3,7 +3,7 @@ jib {
         image = "amazoncorretto:17.0.4-al2"
         platforms {
             platform {
-                architecture = "arm64"
+                architecture = "amd64"
                 os = "linux"
             }
         }

--- a/packy-api/profile-prod.gradle
+++ b/packy-api/profile-prod.gradle
@@ -3,7 +3,7 @@ jib {
         image = "amazoncorretto:17.0.4-al2"
         platforms {
             platform {
-                architecture = "arm64"
+                architecture = "amd64"
                 os = "linux"
             }
         }


### PR DESCRIPTION
## 🛰️ Issue Number
#12 

## 🪐 작업 내용
`WARNING: The requested image's platform (linux/arm64) does not match the detected host platform (linux/amd64/v3) and no specific platform was requested`

위와 같은 Warning과 함께 docker run이 되지 않는 문제가 발생하여 도커 이미지의 아키텍처를 amd64로 변경했습니다.

## 📚 Reference
X

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
