### PR TITLE
deploy: Dockerrun.aws.json 다시 추가

### DIFF
--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,0 +1,13 @@
+{
+  "AWSEBDockerrunVersion": "1",
+  "Image": {
+    "Name": "714646531644.dkr.ecr.ap-northeast-2.amazonaws.com/packy-dev:latest",
+    "Update": "true"
+  },
+  "Ports": [
+    {
+      "ContainerPort": "8082",
+      "HostPort": "8082"
+    }
+  ]
+}


### PR DESCRIPTION
## 🛰️ Issue Number
#12 

## 🪐 작업 내용
Dockerrun.aws.json 파일이 없어도 되는줄 알았으나 Dockerfile을 사용하고 있지 않기 때문에 Dockerrun.aws.json 파일이 필요합니다.
더불어 8081번으로 기입했던 포트를 8082번으로 수정하였습니다.

## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
