### PR TITLE
setting: 개발 서버 에러를 슬랙으로 알림 전송

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,6 @@ out/
 .vscode/
 
 ### application.yml ###
-/packy-api/src/main/resources/
-/packy-domain/src/main/resources/
+packy-api/src/main/resources/*.yml
+packy-api/src/main/resources/*.p8
+packy-domain/src/main/resources/

--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,4 @@ out/
 ### application.yml ###
 packy-api/src/main/resources/*.yml
 packy-api/src/main/resources/*.p8
-packy-domain/src/main/resources/
+packy-domain/src/main/resources/*.yml

--- a/packy-api/build.gradle
+++ b/packy-api/build.gradle
@@ -40,6 +40,9 @@ dependencies {
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+
+    // logback
+    implementation 'com.github.maricn:logback-slack-appender:1.6.1'
 }
 
 test {

--- a/packy-api/src/main/resources/application-api.yml
+++ b/packy-api/src/main/resources/application-api.yml
@@ -1,2 +1,0 @@
-server:
-  port: 8081

--- a/packy-api/src/main/resources/logback.xml
+++ b/packy-api/src/main/resources/logback.xml
@@ -1,0 +1,42 @@
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <springProfile name="local">
+        <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="dev">
+        <property resource="application-api.yml"/>
+        <springProperty name="SLACK_WEBHOOK_URL" source="logging.slack.webhook-url.dev"/>
+        <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
+            <webhookUri>${SLACK_WEBHOOK_URL}</webhookUri>
+            <channel>패키-서버-에러-dev</channel>
+            <layout class="ch.qos.logback.classic.PatternLayout">
+                <pattern>%date %-5level - %msg%n</pattern>
+            </layout>
+            <colorCoding>true</colorCoding>
+        </appender>
+
+        <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
+                <charset>utf8</charset>
+            </encoder>
+        </appender>
+
+        <appender name="ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
+            <appender-ref ref="SLACK"/>
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>ERROR</level>
+            </filter>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="Console"/>
+            <appender-ref ref="ASYNC_SLACK"/>
+        </root>
+    </springProfile>
+</configuration>

--- a/packy-domain/src/main/resources/data.sql
+++ b/packy-domain/src/main/resources/data.sql
@@ -1,0 +1,6 @@
+insert into profile_image (img_url)
+values ('https://i.namu.wiki/i/ColQt99Ihs3__vEx5_WU-suvLoublbI759tqUZXkR5S0Mw7mdPUetnOC5apdIiA3W-6_1pHgHGt_jW0vawnoprvckgMI4BnZW_M6knOfsmE4EY-Wh3fB9Sqvw1cZcOepAs2H66LIT71GAVhX084JIg.webp'),
+       ('https://i.namu.wiki/i/VM0HKbO6P_3h9UAkcpkdrAuh5u9u4do8Zk_jzH2ogoR3tPZzDJMPjaPJFfQhfljQs79HulYqbnyxhhcsuFMtclynGmVWv4cWdWBHmRoN3i65ATyUmma-g63f5csVFc0JMqeIUisGaD_f6D83kMvBbg.webp'),
+       ('https://i.namu.wiki/i/T-5Ct-xiiSTe9IziaMTWTHG9Y4s6HyFmvgMpBirXQ4iXI2J2V-vpeKbZTbNdEy9nXDObh4yxmDxWnsEDjThQ0s0N2ugFCBi0yPpsNPdaotA_snhfODPyhgYswKlpIAIUR3sS9c92LeKk-L4CGwzTjA.webp'),
+       ('https://i.namu.wiki/i/b4FeNnpcwDt7ySrOmx-JNbcNzfTaPD4bFTy4drseaA5t0-gzSuoBrqSHM_cA56yGUOUSBvATYYQkQpMJ-Gs6zKqv0BzajruwccEDhy1Gpt5JjWBB3EP7Rhnofxpd6nnRXDq4mi3iiLQEHe2uhZUO6Q.webp');
+


### PR DESCRIPTION
## 🛰️ Issue Number
#28 

## 🪐 작업 내용
- logback을 활용하여 개발 서버에서 발생한 ERROR 로그를 슬랙으로 전송하도록 slack appender 의존성을 추가하고 logback.xml을 작성하였습니다.
- .gitignore의 범위가 resources 폴더 전체로 하면 형상 관리가 필요한 파일도 업로드되지 않기 때문에 ignore의 범위를 yml과 p8 파일에 한하도록 수정하였습니다.

## 📚 Reference
- https://mopil.tistory.com/160
- https://leeeeeyeon-dev.tistory.com/3

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
