### PR TITLE
fix: API Response에서 code 값이 enum 값과 같도록 수정

### DIFF
--- a/packy-api/src/main/java/com/dilly/global/response/DataResponseDto.java
+++ b/packy-api/src/main/java/com/dilly/global/response/DataResponseDto.java
@@ -5,14 +5,14 @@ import lombok.Getter;
 @Getter
 public class DataResponseDto<T> extends ResponseDto {
 
-    private final T data;
+	private final T data;
 
-    private DataResponseDto(T data) {
-        super(ErrorCode.OK.getCode(), ErrorCode.OK.getMessage());
-        this.data = data;
-    }
+	private DataResponseDto(T data) {
+		super(ErrorCode.OK.toString(), ErrorCode.OK.getMessage());
+		this.data = data;
+	}
 
-    public static <T> DataResponseDto<T> from(T data) {
-        return new DataResponseDto<>(data);
-    }
+	public static <T> DataResponseDto<T> from(T data) {
+		return new DataResponseDto<>(data);
+	}
 }

--- a/packy-api/src/main/java/com/dilly/global/response/ErrorCode.java
+++ b/packy-api/src/main/java/com/dilly/global/response/ErrorCode.java
@@ -13,33 +13,32 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode {
 
 	// Success
-	OK("OK000", HttpStatus.OK, "OK"),
+	OK(HttpStatus.OK, "OK"),
 
 	// Internal Server Error
-	INTERNAL_ERROR("SERVER000", HttpStatus.INTERNAL_SERVER_ERROR, "서버에 오류가 발생했습니다."),
-	METHOD_NOT_ALLOWED("SERVER001", HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP Method 요청입니다."),
-	KAKAO_SERVER_ERROR("SERVER002", HttpStatus.INTERNAL_SERVER_ERROR, "카카오 서버 연동에 오류가 발생했습니다."),
-	API_NOT_FOUND("SERVER003", HttpStatus.NOT_FOUND, "요청한 API를 찾을 수 없습니다."),
+	INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 오류가 발생했습니다."),
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP Method 요청입니다."),
+	KAKAO_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 서버 연동에 오류가 발생했습니다."),
+	API_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 API를 찾을 수 없습니다."),
 
 	// Authorization
-	NOT_SUPPORTED_LOGIN_TYPE("AUTH000", HttpStatus.BAD_REQUEST, "지원하지 않는 로그인 타입입니다."),
-	UNAUTHORIZED("AUTH001", HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
-	MALFORMED_JWT("AUTH002", HttpStatus.UNAUTHORIZED, "올바르지 않은 형식의 JWT 토큰입니다."),
-	EXPIRED_JWT("AUTH003", HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
-	UNSUPPORTED_JWT("AUTH004", HttpStatus.UNAUTHORIZED, "지원하지 않는 JWT 토큰입니다."),
-	ILLEGAL_JWT("AUTH005", HttpStatus.UNAUTHORIZED, "잘못된 JWT 토큰입니다."),
-	INVALID_REFRESH_TOKEN("AUTH006", HttpStatus.UNAUTHORIZED, "유효하지 않은 Refresh Token입니다."),
-	AUTH_INFO_NOT_FOUND("AUTH007", HttpStatus.UNAUTHORIZED, "Security Context에 인증 정보가 없습니다."),
+	NOT_SUPPORTED_LOGIN_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 로그인 타입입니다."),
+	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+	MALFORMED_JWT(HttpStatus.UNAUTHORIZED, "올바르지 않은 형식의 JWT 토큰입니다."),
+	EXPIRED_JWT(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
+	UNSUPPORTED_JWT(HttpStatus.UNAUTHORIZED, "지원하지 않는 JWT 토큰입니다."),
+	ILLEGAL_JWT(HttpStatus.UNAUTHORIZED, "잘못된 JWT 토큰입니다."),
+	INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 Refresh Token입니다."),
+	AUTH_INFO_NOT_FOUND(HttpStatus.UNAUTHORIZED, "Security Context에 인증 정보가 없습니다."),
 
 	// Not Found
-	MEMBER_NOT_FOUND("NF000", HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
-	PROFILE_IMAGE_NOT_FOUND("NF001", HttpStatus.NOT_FOUND, "프로필 이미지를 찾을 수 없습니다."),
-	REFRESH_TOKEN_NOT_FOUND("NF002", HttpStatus.NOT_FOUND, "Refresh Token을 찾을 수 없습니다."),
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
+	PROFILE_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "프로필 이미지를 찾을 수 없습니다."),
+	REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "Refresh Token을 찾을 수 없습니다."),
 
 	// Member
-	MEMBER_ALREADY_EXIST("M000", HttpStatus.CONFLICT, "이미 가입된 유저입니다.");
+	MEMBER_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 가입된 유저입니다.");
 
-	private final String code;
 	private final HttpStatus httpStatus;
 	private final String message;
 

--- a/packy-api/src/main/java/com/dilly/global/response/ErrorResponseDto.java
+++ b/packy-api/src/main/java/com/dilly/global/response/ErrorResponseDto.java
@@ -2,19 +2,19 @@ package com.dilly.global.response;
 
 public class ErrorResponseDto extends ResponseDto {
 
-    private ErrorResponseDto(ErrorCode errorCode) {
-        super(errorCode.getCode(), errorCode.getMessage());
-    }
+	private ErrorResponseDto(ErrorCode errorCode) {
+		super(errorCode.toString(), errorCode.getMessage());
+	}
 
-    private ErrorResponseDto(ErrorCode errorCode, Exception e) {
-        super(errorCode.getCode(), errorCode.getMessage(e));
-    }
+	private ErrorResponseDto(ErrorCode errorCode, Exception e) {
+		super(errorCode.toString(), errorCode.getMessage(e));
+	}
 
-    public static ErrorResponseDto from(ErrorCode errorCode) {
-        return new ErrorResponseDto(errorCode);
-    }
+	public static ErrorResponseDto from(ErrorCode errorCode) {
+		return new ErrorResponseDto(errorCode);
+	}
 
-    public static ErrorResponseDto of(ErrorCode errorCode, Exception e) {
-        return new ErrorResponseDto(errorCode, e);
-    }
+	public static ErrorResponseDto of(ErrorCode errorCode, Exception e) {
+		return new ErrorResponseDto(errorCode, e);
+	}
 }

--- a/packy-api/src/main/java/com/dilly/global/response/ResponseDto.java
+++ b/packy-api/src/main/java/com/dilly/global/response/ResponseDto.java
@@ -7,10 +7,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ResponseDto {
 
-    private final String code;
-    private final String message;
+	private final String code;
+	private final String message;
 
-    public static ResponseDto of(ErrorCode errorCode) {
-        return new ResponseDto(errorCode.getCode(), errorCode.getMessage());
-    }
+	public static ResponseDto of(ErrorCode errorCode) {
+		return new ResponseDto(errorCode.toString(), errorCode.getMessage());
+	}
 }


### PR DESCRIPTION
## 🛰️ Issue Number
#29 

## 🪐 작업 내용
- 클라이언트의 요청에 따라 code 값이 enum과 같도록 수정하였습니다.
  - 기존 code 값은 관리와 활용도 면에서 모호하다는 의견

## 📚 Reference
X

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
