### PR TITLE
setting: Controller 테스트 코드 작성을 위한 환경 세팅

### DIFF
--- a/.github/workflows/packy-cd.yml
+++ b/.github/workflows/packy-cd.yml
@@ -38,7 +38,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
 
       - name: Build with Gradle
-        run: ./gradlew -Pdev clean jib -x test
+        run: ./gradlew -Pdev clean jib
 
       - name: Get current time
         uses: 1466587594/get-current-time@v2

--- a/packy-api/build.gradle
+++ b/packy-api/build.gradle
@@ -26,11 +26,12 @@ dependencies {
     // oauth
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
 
     // jwt
-    compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
-    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
-    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 
     // webflux (for WebClient)
     implementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/packy-api/src/main/java/com/dilly/ApiApplication.java
+++ b/packy-api/src/main/java/com/dilly/ApiApplication.java
@@ -1,10 +1,19 @@
 package com.dilly;
 
+import java.util.TimeZone;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import jakarta.annotation.PostConstruct;
+
 @SpringBootApplication
 public class ApiApplication {
+
+	@PostConstruct
+	public void init() {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
 
 	public static void main(String[] args) {
 		System.setProperty("spring.config.name", "application-api, application-domain");

--- a/packy-api/src/main/java/com/dilly/ApiApplication.java
+++ b/packy-api/src/main/java/com/dilly/ApiApplication.java
@@ -2,10 +2,8 @@ package com.dilly;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class ApiApplication {
 
 	public static void main(String[] args) {

--- a/packy-api/src/main/java/com/dilly/global/config/JpaAuditingConfig.java
+++ b/packy-api/src/main/java/com/dilly/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.dilly.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/packy-api/src/test/java/com/dilly/ApiApplicationTest.java
+++ b/packy-api/src/test/java/com/dilly/ApiApplicationTest.java
@@ -1,0 +1,12 @@
+package com.dilly;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+class ApiApplicationTest {
+
+	@Test
+	void contextLoads() {
+	}
+}

--- a/packy-api/src/test/java/com/dilly/admin/api/AdminControllerTest.java
+++ b/packy-api/src/test/java/com/dilly/admin/api/AdminControllerTest.java
@@ -1,0 +1,27 @@
+package com.dilly.admin.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.dilly.global.ControllerTestSupport;
+import com.dilly.global.WithCustomMockUser;
+
+class AdminControllerTest extends ControllerTestSupport {
+
+	@DisplayName("서버 상태를 확인한다.")
+	@Test
+	@WithCustomMockUser
+	void healthCheck() throws Exception {
+		// given // when // then
+		// TODO: active profile이 null로 뜸
+		mockMvc.perform(
+				get("/api/v1/admin/health")
+			)
+			.andDo(print())
+			.andExpect(status().isOk());
+	}
+}

--- a/packy-api/src/test/java/com/dilly/global/ControllerTestSupport.java
+++ b/packy-api/src/test/java/com/dilly/global/ControllerTestSupport.java
@@ -1,23 +1,19 @@
 package com.dilly.global;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.dilly.admin.api.AdminController;
 import com.dilly.admin.application.AdminService;
-import com.dilly.global.exception.ErrorCodeController;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(
 	controllers = {
-		AdminController.class,
-		ErrorCodeController.class
+		AdminController.class
 	}
 )
-@AutoConfigureRestDocs
 public abstract class ControllerTestSupport {
 	static {
 		System.setProperty("spring.config.name", "application-test");

--- a/packy-api/src/test/java/com/dilly/global/ControllerTestSupport.java
+++ b/packy-api/src/test/java/com/dilly/global/ControllerTestSupport.java
@@ -1,0 +1,34 @@
+package com.dilly.global;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.dilly.admin.api.AdminController;
+import com.dilly.admin.application.AdminService;
+import com.dilly.global.exception.ErrorCodeController;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(
+	controllers = {
+		AdminController.class,
+		ErrorCodeController.class
+	}
+)
+@AutoConfigureRestDocs
+public abstract class ControllerTestSupport {
+	static {
+		System.setProperty("spring.config.name", "application-test");
+	}
+
+	@Autowired
+	protected MockMvc mockMvc;
+
+	@Autowired
+	protected ObjectMapper objectMapper;
+
+	@MockBean
+	protected AdminService adminService;
+}

--- a/packy-api/src/test/java/com/dilly/global/WithCustomMockUser.java
+++ b/packy-api/src/test/java/com/dilly/global/WithCustomMockUser.java
@@ -1,0 +1,13 @@
+package com.dilly.global;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithCustomMockUserSecurityContextFactory.class)
+public @interface WithCustomMockUser {
+
+	String id() default "1";
+}

--- a/packy-api/src/test/java/com/dilly/global/WithCustomMockUserSecurityContextFactory.java
+++ b/packy-api/src/test/java/com/dilly/global/WithCustomMockUserSecurityContextFactory.java
@@ -1,0 +1,74 @@
+package com.dilly.global;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.dilly.member.Role;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+
+@ActiveProfiles("test")
+public class WithCustomMockUserSecurityContextFactory implements WithSecurityContextFactory<WithCustomMockUser> {
+
+	@Value("${jwt.secret}")
+	String secretKey;
+
+	@Override
+	public SecurityContext createSecurityContext(WithCustomMockUser annotation) {
+		final SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+
+		Claims claims;
+		UserDetails principal;
+		Collection<? extends GrantedAuthority> authorities;
+
+		long now = (new Date()).getTime();
+		long acessTokenExpireTime = 1000 * 60 * 30;
+		Date accessTokenExpiresIn = new Date(now + acessTokenExpireTime);
+
+		byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+		Key key = Keys.hmacShaKeyFor(keyBytes);
+
+		String accessToken = Jwts.builder()
+			.setSubject(annotation.id())
+			.claim("provider", "KAKAO")
+			.claim("nickname", "테스트")
+			.claim("auth", Role.ROLE_USER)
+			.setExpiration(accessTokenExpiresIn) // 토큰 만료 시간 설정
+			.signWith(key, SignatureAlgorithm.HS512)
+			.compact(); // 토큰 생성
+
+		claims = Jwts.parserBuilder()
+			.setSigningKey(key)
+			.build()
+			.parseClaimsJws(accessToken)
+			.getBody();
+		authorities = Arrays.stream(claims.get("auth").toString().split(","))
+			.map(SimpleGrantedAuthority::new)
+			.toList();
+		principal = new User(claims.getSubject(), "", authorities);
+
+		final UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+			principal, "", authorities
+		);
+		securityContext.setAuthentication(authenticationToken);
+		return securityContext;
+
+	}
+}

--- a/packy-api/src/test/resources/application-test.yml
+++ b/packy-api/src/test/resources/application-test.yml
@@ -1,0 +1,2 @@
+jwt:
+  secret: 'testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest'


### PR DESCRIPTION
## 🛰️ Issue Number
#34 

## 🪐 작업 내용
- Controller 단 테스트 코드 작성을 위해 기본적으로 필요한 코드를 추가하였습니다.
  - ControllerTestSupport
  - @WithMockUser 어노테이션 구현
- Controller 단 테스트 코드 예시를 위해 AdminController에 대한 테스트 코드를 작성하였습니다.
- 테스트 코드 작성 중 JpaAuditing 관련 에러가 발생하여 JpaAuditing 관련 설정을 Application 실행 클래스에서 분리하였습니다.
- Application의 timezone을 Asia/Seoul로 설정하였습니다.
- CI/CD 스크립트에서 빌드 시 테스트 코드를 무시하는 옵션을 제거하였습니다.

## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
