### PR TITLE
feat: Server Driven 관련 조회 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ out/
 packy-api/src/main/resources/*.yml
 packy-api/src/main/resources/*.p8
 packy-domain/src/main/resources/*.yml
+packy-domain/src/main/resources/*.sql

--- a/db.vuerd.json
+++ b/db.vuerd.json
@@ -3,9 +3,9 @@
     "version": "2.2.11",
     "width": 2500,
     "height": 2500,
-    "scrollTop": 0,
-    "scrollLeft": 0,
-    "zoomLevel": 0.3,
+    "scrollTop": -251,
+    "scrollLeft": -1339,
+    "zoomLevel": 0.8,
     "show": {
       "tableComment": true,
       "columnComment": true,
@@ -751,9 +751,9 @@
         ],
         "ui": {
           "active": false,
-          "left": 2060.7934,
+          "left": 2076.7934,
           "top": 413.6199,
-          "zIndex": 2,
+          "zIndex": 31,
           "widthName": 60,
           "widthComment": 60
         },
@@ -812,7 +812,7 @@
           },
           {
             "id": "151107b9-e942-47df-97dd-8b5de5918ce9",
-            "name": "envelopeId",
+            "name": "letterPaperId",
             "comment": "",
             "dataType": "BIGINT",
             "default": "",
@@ -827,7 +827,7 @@
               "pk": false,
               "fk": true,
               "pfk": false,
-              "widthName": 62.29393005371094,
+              "widthName": 73.20088195800781,
               "widthComment": 60,
               "widthDataType": 60,
               "widthDefault": 60
@@ -836,9 +836,9 @@
         ],
         "ui": {
           "active": false,
-          "left": 1569.587,
-          "top": 298.5784,
-          "zIndex": 3,
+          "left": 1490.587,
+          "top": 328.5784,
+          "zIndex": 21,
           "widthName": 60,
           "widthComment": 60
         },
@@ -1101,7 +1101,7 @@
       },
       {
         "id": "f7dd4680-c8f4-4b8a-b764-2d5c27742e1b",
-        "name": "Youtube",
+        "name": "Music",
         "comment": "패키 유튜브 (Admin)",
         "columns": [
           {
@@ -1149,59 +1149,13 @@
               "widthDataType": 60,
               "widthDefault": 60
             }
-          },
-          {
-            "id": "8cf14a33-c64e-4b78-8c4b-f6fab9e40c07",
-            "name": "title",
-            "comment": "",
-            "dataType": "VARCHAR",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "411f3d71-e1dc-4367-a385-a1edf1f4bc49",
-            "name": "thumbnailUrl",
-            "comment": "",
-            "dataType": "TEXT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": false
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 72.87588500976562,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
           }
         ],
         "ui": {
           "active": false,
           "left": 2063,
           "top": 552,
-          "zIndex": 12,
+          "zIndex": 30,
           "widthName": 60,
           "widthComment": 108.61288452148438
         },
@@ -1209,7 +1163,7 @@
       },
       {
         "id": "18ab0bbe-f634-4cc1-9573-66fa5a02b2a3",
-        "name": "Hashtag",
+        "name": "MusicHashtag",
         "comment": "해시태그",
         "columns": [
           {
@@ -1286,8 +1240,8 @@
           "active": false,
           "left": 2114,
           "top": 794,
-          "zIndex": 11,
-          "widthName": 60,
+          "zIndex": 26,
+          "widthName": 77.81587219238281,
           "widthComment": 60
         },
         "visible": true
@@ -1754,7 +1708,7 @@
           "columnIds": [
             "4cf90644-8fb3-4634-abe8-d19ccc01288d"
           ],
-          "x": 2060.7934,
+          "x": 2076.7934,
           "y": 468.6199,
           "direction": "left"
         },
@@ -1780,8 +1734,8 @@
           "columnIds": [
             "6d36f191-020b-427f-aa19-fca9b53ea4f1"
           ],
-          "x": 1744.2339650268555,
-          "y": 298.5784,
+          "x": 1670.687440979004,
+          "y": 328.5784,
           "direction": "top"
         },
         "end": {
@@ -1815,8 +1769,8 @@
           "columnIds": [
             "151107b9-e942-47df-97dd-8b5de5918ce9"
           ],
-          "x": 1744.2339650268555,
-          "y": 429.0784,
+          "x": 1670.687440979004,
+          "y": 459.0784,
           "direction": "bottom"
         },
         "constraintName": "fk_envelope_to_letter",
@@ -1884,8 +1838,8 @@
           "columnIds": [
             "a8ea215a-a2c2-4669-bba0-259843dd030c"
           ],
-          "x": 2242.937942504883,
-          "y": 703,
+          "x": 2238.0304641723633,
+          "y": 662,
           "direction": "bottom"
         },
         "end": {

--- a/packy-api/src/main/java/com/dilly/admin/api/AdminController.java
+++ b/packy-api/src/main/java/com/dilly/admin/api/AdminController.java
@@ -7,7 +7,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.dilly.admin.application.AdminService;
+import com.dilly.admin.dto.response.BoxImgResponse;
 import com.dilly.admin.dto.response.ImgResponse;
+import com.dilly.admin.dto.response.LetterImgResponse;
+import com.dilly.admin.dto.response.MusicResponse;
 import com.dilly.global.response.DataResponseDto;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,5 +37,29 @@ public class AdminController {
 	@GetMapping("/design/profiles")
 	public DataResponseDto<List<ImgResponse>> getProfiles() {
 		return DataResponseDto.from(adminService.getProfiles());
+	}
+
+	@Operation(summary = "박스 디자인 조회")
+	@GetMapping("/design/boxes")
+	public DataResponseDto<List<BoxImgResponse>> getBoxes() {
+		return DataResponseDto.from(adminService.getBoxes());
+	}
+
+	@Operation(summary = "메시지 디자인 조회")
+	@GetMapping("/design/messages")
+	public DataResponseDto<List<ImgResponse>> getMessages() {
+		return DataResponseDto.from(adminService.getMessages());
+	}
+
+	@Operation(summary = "편지지 디자인 조회")
+	@GetMapping("/design/letters")
+	public DataResponseDto<List<LetterImgResponse>> getLetters() {
+		return DataResponseDto.from(adminService.getLetters());
+	}
+
+	@Operation(summary = "패키 추천 음악 조회")
+	@GetMapping("/music")
+	public DataResponseDto<List<MusicResponse>> getMusics() {
+		return DataResponseDto.from(adminService.getMusics());
 	}
 }

--- a/packy-api/src/main/java/com/dilly/admin/application/AdminService.java
+++ b/packy-api/src/main/java/com/dilly/admin/application/AdminService.java
@@ -5,8 +5,15 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.dilly.admin.ProfileImageReader;
+import com.dilly.admin.domain.BoxReader;
+import com.dilly.admin.domain.LetterReader;
+import com.dilly.admin.domain.MessageReader;
+import com.dilly.admin.domain.MusicReader;
+import com.dilly.admin.domain.ProfileImageReader;
+import com.dilly.admin.dto.response.BoxImgResponse;
 import com.dilly.admin.dto.response.ImgResponse;
+import com.dilly.admin.dto.response.LetterImgResponse;
+import com.dilly.admin.dto.response.MusicResponse;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,8 +25,28 @@ import lombok.extern.slf4j.Slf4j;
 public class AdminService {
 
 	private final ProfileImageReader profileImageReader;
+	private final BoxReader boxReader;
+	private final MessageReader messageReader;
+	private final LetterReader letterReader;
+	private final MusicReader musicReader;
 
 	public List<ImgResponse> getProfiles() {
 		return profileImageReader.findAll();
+	}
+
+	public List<BoxImgResponse> getBoxes() {
+		return boxReader.findAll();
+	}
+
+	public List<ImgResponse> getMessages() {
+		return messageReader.findAll();
+	}
+
+	public List<LetterImgResponse> getLetters() {
+		return letterReader.findAll();
+	}
+
+	public List<MusicResponse> getMusics() {
+		return musicReader.findAll();
 	}
 }

--- a/packy-api/src/main/java/com/dilly/admin/domain/BoxReader.java
+++ b/packy-api/src/main/java/com/dilly/admin/domain/BoxReader.java
@@ -1,0 +1,28 @@
+package com.dilly.admin.domain;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.dilly.admin.dao.BoxRepository;
+import com.dilly.admin.dto.response.BoxImgResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class BoxReader {
+
+	private final BoxRepository boxRepository;
+
+	public List<BoxImgResponse> findAll() {
+		return boxRepository.findAll().stream()
+			.map(box -> BoxImgResponse.builder()
+				.id(box.getId())
+				.boxTop(box.getTopImgUrl())
+				.boxBottom(box.getBottomImgUrl())
+				.build()
+			)
+			.toList();
+	}
+}

--- a/packy-api/src/main/java/com/dilly/admin/domain/LetterReader.java
+++ b/packy-api/src/main/java/com/dilly/admin/domain/LetterReader.java
@@ -1,0 +1,28 @@
+package com.dilly.admin.domain;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.dilly.admin.dao.LetterRepository;
+import com.dilly.admin.dto.response.LetterImgResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class LetterReader {
+
+	private final LetterRepository letterRepository;
+
+	public List<LetterImgResponse> findAll() {
+		return letterRepository.findAll().stream()
+			.map(letter -> LetterImgResponse.builder()
+				.id(letter.getId())
+				.letterPaper(letter.getLetterPaper().getWritingPaperUrl())
+				.envelope(letter.getLetterPaper().getEnvelopeUrl())
+				.build()
+			)
+			.toList();
+	}
+}

--- a/packy-api/src/main/java/com/dilly/admin/domain/MessageReader.java
+++ b/packy-api/src/main/java/com/dilly/admin/domain/MessageReader.java
@@ -1,0 +1,27 @@
+package com.dilly.admin.domain;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.dilly.admin.dao.MessageRepository;
+import com.dilly.admin.dto.response.ImgResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MessageReader {
+
+	private final MessageRepository messageRepository;
+
+	public List<ImgResponse> findAll() {
+		return messageRepository.findAll().stream()
+			.map(message -> ImgResponse.builder()
+				.id(message.getId())
+				.imgUrl(message.getImgUrl())
+				.build()
+			)
+			.toList();
+	}
+}

--- a/packy-api/src/main/java/com/dilly/admin/domain/MusicReader.java
+++ b/packy-api/src/main/java/com/dilly/admin/domain/MusicReader.java
@@ -1,0 +1,36 @@
+package com.dilly.admin.domain;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.dilly.admin.Music;
+import com.dilly.admin.MusicHashtag;
+import com.dilly.admin.dao.MusicRepository;
+import com.dilly.admin.dto.response.MusicResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MusicReader {
+
+	private final MusicRepository musicRepository;
+
+	public List<MusicResponse> findAll() {
+		return musicRepository.findAll().stream()
+			.map(music -> MusicResponse.builder()
+				.id(music.getId())
+				.youtubeUrl(music.getYoutubeUrl())
+				.hashtags(getHashTags(music))
+				.build()
+			)
+			.toList();
+	}
+
+	private List<String> getHashTags(Music music) {
+		return music.getHashtags().stream()
+			.map(MusicHashtag::getHashtag)
+			.toList();
+	}
+}

--- a/packy-api/src/main/java/com/dilly/admin/domain/ProfileImageReader.java
+++ b/packy-api/src/main/java/com/dilly/admin/domain/ProfileImageReader.java
@@ -1,9 +1,11 @@
-package com.dilly.admin;
+package com.dilly.admin.domain;
 
 import java.util.List;
 
 import org.springframework.stereotype.Component;
 
+import com.dilly.admin.ProfileImage;
+import com.dilly.admin.dao.ProfileImageRepository;
 import com.dilly.admin.dto.response.ImgResponse;
 
 import lombok.RequiredArgsConstructor;

--- a/packy-api/src/main/java/com/dilly/admin/dto/response/BoxImgResponse.java
+++ b/packy-api/src/main/java/com/dilly/admin/dto/response/BoxImgResponse.java
@@ -1,0 +1,11 @@
+package com.dilly.admin.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record BoxImgResponse(
+	Long id,
+	String boxTop,
+	String boxBottom
+) {
+}

--- a/packy-api/src/main/java/com/dilly/admin/dto/response/LetterImgResponse.java
+++ b/packy-api/src/main/java/com/dilly/admin/dto/response/LetterImgResponse.java
@@ -1,0 +1,11 @@
+package com.dilly.admin.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record LetterImgResponse(
+	Long id,
+	String letterPaper,
+	String envelope
+) {
+}

--- a/packy-api/src/main/java/com/dilly/admin/dto/response/MusicResponse.java
+++ b/packy-api/src/main/java/com/dilly/admin/dto/response/MusicResponse.java
@@ -1,0 +1,13 @@
+package com.dilly.admin.dto.response;
+
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record MusicResponse(
+	Long id,
+	String youtubeUrl,
+	List<String> hashtags
+) {
+}

--- a/packy-api/src/main/java/com/dilly/auth/application/AuthService.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/AuthService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.dilly.admin.ProfileImage;
-import com.dilly.admin.ProfileImageReader;
+import com.dilly.admin.domain.ProfileImageReader;
 import com.dilly.auth.domain.KakaoAccountReader;
 import com.dilly.auth.domain.KakaoAccountWriter;
 import com.dilly.auth.dto.request.SignupRequest;

--- a/packy-domain/src/main/java/com/dilly/admin/Box.java
+++ b/packy-domain/src/main/java/com/dilly/admin/Box.java
@@ -1,0 +1,21 @@
+package com.dilly.admin;
+
+import static jakarta.persistence.GenerationType.*;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Box {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+
+	private String topImgUrl;
+
+	private String bottomImgUrl;
+}

--- a/packy-domain/src/main/java/com/dilly/admin/Letter.java
+++ b/packy-domain/src/main/java/com/dilly/admin/Letter.java
@@ -1,0 +1,24 @@
+package com.dilly.admin;
+
+import static jakarta.persistence.GenerationType.*;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Letter {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+
+	private String content;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private LetterPaper letterPaper;
+}

--- a/packy-domain/src/main/java/com/dilly/admin/LetterPaper.java
+++ b/packy-domain/src/main/java/com/dilly/admin/LetterPaper.java
@@ -1,0 +1,21 @@
+package com.dilly.admin;
+
+import static jakarta.persistence.GenerationType.*;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class LetterPaper {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+
+	private String envelopeUrl;
+
+	private String writingPaperUrl;
+}

--- a/packy-domain/src/main/java/com/dilly/admin/Message.java
+++ b/packy-domain/src/main/java/com/dilly/admin/Message.java
@@ -1,0 +1,19 @@
+package com.dilly.admin;
+
+import static jakarta.persistence.GenerationType.*;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Message {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+
+	private String imgUrl;
+}

--- a/packy-domain/src/main/java/com/dilly/admin/Music.java
+++ b/packy-domain/src/main/java/com/dilly/admin/Music.java
@@ -1,0 +1,25 @@
+package com.dilly.admin;
+
+import static jakarta.persistence.GenerationType.*;
+
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Music {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+
+	private String youtubeUrl;
+
+	@OneToMany(mappedBy = "music")
+	private List<MusicHashtag> hashtags;
+}

--- a/packy-domain/src/main/java/com/dilly/admin/MusicHashtag.java
+++ b/packy-domain/src/main/java/com/dilly/admin/MusicHashtag.java
@@ -1,0 +1,24 @@
+package com.dilly.admin;
+
+import static jakarta.persistence.GenerationType.*;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class MusicHashtag {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+
+	private String hashtag;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Music music;
+}

--- a/packy-domain/src/main/java/com/dilly/admin/dao/BoxRepository.java
+++ b/packy-domain/src/main/java/com/dilly/admin/dao/BoxRepository.java
@@ -1,0 +1,8 @@
+package com.dilly.admin.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.dilly.admin.Box;
+
+public interface BoxRepository extends JpaRepository<Box, Long> {
+}

--- a/packy-domain/src/main/java/com/dilly/admin/dao/LetterPaperRepository.java
+++ b/packy-domain/src/main/java/com/dilly/admin/dao/LetterPaperRepository.java
@@ -1,0 +1,8 @@
+package com.dilly.admin.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.dilly.admin.LetterPaper;
+
+public interface LetterPaperRepository extends JpaRepository<LetterPaper, Long> {
+}

--- a/packy-domain/src/main/java/com/dilly/admin/dao/LetterRepository.java
+++ b/packy-domain/src/main/java/com/dilly/admin/dao/LetterRepository.java
@@ -1,0 +1,8 @@
+package com.dilly.admin.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.dilly.admin.Letter;
+
+public interface LetterRepository extends JpaRepository<Letter, Long> {
+}

--- a/packy-domain/src/main/java/com/dilly/admin/dao/MessageRepository.java
+++ b/packy-domain/src/main/java/com/dilly/admin/dao/MessageRepository.java
@@ -1,0 +1,8 @@
+package com.dilly.admin.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.dilly.admin.Message;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+}

--- a/packy-domain/src/main/java/com/dilly/admin/dao/MusicHashtagRepository.java
+++ b/packy-domain/src/main/java/com/dilly/admin/dao/MusicHashtagRepository.java
@@ -1,0 +1,8 @@
+package com.dilly.admin.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.dilly.admin.MusicHashtag;
+
+public interface MusicHashtagRepository extends JpaRepository<MusicHashtag, Long> {
+}

--- a/packy-domain/src/main/java/com/dilly/admin/dao/MusicRepository.java
+++ b/packy-domain/src/main/java/com/dilly/admin/dao/MusicRepository.java
@@ -1,0 +1,8 @@
+package com.dilly.admin.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.dilly.admin.Music;
+
+public interface MusicRepository extends JpaRepository<Music, Long> {
+}

--- a/packy-domain/src/main/java/com/dilly/admin/dao/ProfileImageRepository.java
+++ b/packy-domain/src/main/java/com/dilly/admin/dao/ProfileImageRepository.java
@@ -1,6 +1,8 @@
-package com.dilly.admin;
+package com.dilly.admin.dao;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.dilly.admin.ProfileImage;
 
 public interface ProfileImageRepository extends JpaRepository<ProfileImage, Long> {
 }

--- a/packy-domain/src/main/resources/data.sql
+++ b/packy-domain/src/main/resources/data.sql
@@ -1,6 +1,0 @@
-insert into profile_image (img_url)
-values ('https://i.namu.wiki/i/ColQt99Ihs3__vEx5_WU-suvLoublbI759tqUZXkR5S0Mw7mdPUetnOC5apdIiA3W-6_1pHgHGt_jW0vawnoprvckgMI4BnZW_M6knOfsmE4EY-Wh3fB9Sqvw1cZcOepAs2H66LIT71GAVhX084JIg.webp'),
-       ('https://i.namu.wiki/i/VM0HKbO6P_3h9UAkcpkdrAuh5u9u4do8Zk_jzH2ogoR3tPZzDJMPjaPJFfQhfljQs79HulYqbnyxhhcsuFMtclynGmVWv4cWdWBHmRoN3i65ATyUmma-g63f5csVFc0JMqeIUisGaD_f6D83kMvBbg.webp'),
-       ('https://i.namu.wiki/i/T-5Ct-xiiSTe9IziaMTWTHG9Y4s6HyFmvgMpBirXQ4iXI2J2V-vpeKbZTbNdEy9nXDObh4yxmDxWnsEDjThQ0s0N2ugFCBi0yPpsNPdaotA_snhfODPyhgYswKlpIAIUR3sS9c92LeKk-L4CGwzTjA.webp'),
-       ('https://i.namu.wiki/i/b4FeNnpcwDt7ySrOmx-JNbcNzfTaPD4bFTy4drseaA5t0-gzSuoBrqSHM_cA56yGUOUSBvATYYQkQpMJ-Gs6zKqv0BzajruwccEDhy1Gpt5JjWBB3EP7Rhnofxpd6nnRXDq4mi3iiLQEHe2uhZUO6Q.webp');
-


### PR DESCRIPTION
## 🛰️ Issue Number
#32 

## 🪐 작업 내용
- 아래 API들을 구현하였습니다. (박스 내부 디자인의 경우 response에 대해 고민이 필요하여 추후 PR로 올리겠습니다.)
  - 박스 디자인 조회
  - 메시지 디자인 조회
  - 편지지 디자인 조회
  - 패키 추천 음악 조회
- 엔티티를 설계하며 일부 테이블과 컬럼의 이름을 변경하였으며, 그에 따라 ERD를 수정하였습니다.
- data.sql을 .gitignore에 추가하였습니다. (현재 S3는 퍼블릭으로 공개되어 있기 때문에 이미지 URL을 통해 버킷 정보를 유추하여 접근하는 경우를 예방)

## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
