### PR TITLE
fix: 편지지 디자인 조회 API LetterPaper와 매핑되도록 수정

### DIFF
--- a/packy-api/src/main/java/com/dilly/admin/domain/LetterReader.java
+++ b/packy-api/src/main/java/com/dilly/admin/domain/LetterReader.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
-import com.dilly.admin.dao.LetterRepository;
+import com.dilly.admin.dao.LetterPaperRepository;
 import com.dilly.admin.dto.response.LetterImgResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -13,16 +13,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class LetterReader {
 
-	private final LetterRepository letterRepository;
+	private final LetterPaperRepository letterPaperRepository;
 
 	public List<LetterImgResponse> findAll() {
-		return letterRepository.findAll().stream()
-			.map(letter -> LetterImgResponse.builder()
-				.id(letter.getId())
-				.letterPaper(letter.getLetterPaper().getWritingPaperUrl())
-				.envelope(letter.getLetterPaper().getEnvelopeUrl())
-				.build()
-			)
+		return letterPaperRepository.findAll().stream()
+			.map(letterPaper -> LetterImgResponse.builder()
+				.id(letterPaper.getId())
+				.letterPaper(letterPaper.getWritingPaperUrl())
+				.envelope(letterPaper.getEnvelopeUrl())
+				.build())
 			.toList();
 	}
 }


### PR DESCRIPTION
## 🛰️ Issue Number
#39 

## 🪐 작업 내용
- 편지지 디자인 조회 API가 LetterPaper 엔티티와 매핑되어야 하지만 Letter 엔티티로 매핑 실수를 했으며, 해당 부분을 수정하였습니다.

## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
