### PR TITLE
feat: S3 Presigned URL 발급 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ packy-api/src/main/resources/*.yml
 packy-api/src/main/resources/*.p8
 packy-domain/src/main/resources/*.yml
 packy-domain/src/main/resources/*.sql
+packy-infra/src/main/resources/*.yml

--- a/packy-api/build.gradle
+++ b/packy-api/build.gradle
@@ -13,6 +13,7 @@ repositories {
 dependencies {
     // multi module
     implementation project(':packy-domain')
+    implementation project(':packy-infra')
 
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/packy-api/src/main/java/com/dilly/ApiApplication.java
+++ b/packy-api/src/main/java/com/dilly/ApiApplication.java
@@ -16,7 +16,7 @@ public class ApiApplication {
 	}
 
 	public static void main(String[] args) {
-		System.setProperty("spring.config.name", "application-api, application-domain");
+		System.setProperty("spring.config.name", "application-api, application-domain, application-infra");
 		SpringApplication.run(ApiApplication.class, args);
 	}
 }

--- a/packy-api/src/main/java/com/dilly/file/FileController.java
+++ b/packy-api/src/main/java/com/dilly/file/FileController.java
@@ -1,0 +1,33 @@
+package com.dilly.file;
+
+import java.util.Map;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.dilly.application.FileService;
+import com.dilly.global.response.DataResponseDto;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "파일 관련 API")
+@RestController
+@RequestMapping("/api/v1/file")
+@RequiredArgsConstructor
+public class FileController {
+
+	private final FileService fileService;
+
+	@Operation(summary = "Presigned URL 생성")
+	@GetMapping("/presigned-url/{fileName}")
+	public DataResponseDto<Map<String, String>> getPresignedUrl(
+		@PathVariable(name = "fileName") @Schema(description = "확장자명을 포함해주세요")
+		String fileName) {
+		return DataResponseDto.from(fileService.getPresignedUrl("images", fileName));
+	}
+}

--- a/packy-infra/build.gradle
+++ b/packy-infra/build.gradle
@@ -12,10 +12,21 @@ repositories {
 dependencies {
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+
+    // aws
+    implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
+    implementation 'io.awspring.cloud:spring-cloud-starter-aws-secrets-manager-config:2.4.4'
 }
 
 test {
     useJUnitPlatform()
+}
+
+processResources.dependsOn('copySecret')
+tasks.register('copySecret', Copy) {
+    from '../packy-submodule/infra'
+    include '*'
+    into './src/main/resources'
 }
 
 bootJar.enabled = false

--- a/packy-infra/src/main/java/com/dilly/application/FileService.java
+++ b/packy-infra/src/main/java/com/dilly/application/FileService.java
@@ -1,0 +1,69 @@
+package com.dilly.application;
+
+import java.net.URL;
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.Headers;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class FileService {
+
+	@Value("${cloud.s3.bucket}")
+	private String bucket;
+
+	private final AmazonS3 amazonS3;
+
+	public Map<String, String> getPresignedUrl(String prefix, String fileName) {
+		if (!prefix.isEmpty()) {
+			fileName = createPath(prefix, fileName);
+		}
+
+		GeneratePresignedUrlRequest generatePresignedUrlRequest = getGeneratePresignedUrlRequest(bucket, fileName);
+		URL url = amazonS3.generatePresignedUrl(generatePresignedUrlRequest);
+
+		return Map.of("url", url.toString());
+	}
+
+	private GeneratePresignedUrlRequest getGeneratePresignedUrlRequest(String bucket, String fileName) {
+		GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucket, fileName)
+			.withMethod(HttpMethod.PUT)
+			.withExpiration(getPresignedUrlExpiration());
+
+		generatePresignedUrlRequest.addRequestParameter(
+			Headers.S3_CANNED_ACL,
+			CannedAccessControlList.PublicRead.toString()
+		);
+
+		return generatePresignedUrlRequest;
+	}
+
+	private Date getPresignedUrlExpiration() {
+		Date expiration = new Date();
+		long expTimeMillis = expiration.getTime();
+		expTimeMillis += 1000 * 60 * 2;
+		expiration.setTime(expTimeMillis);
+
+		return expiration;
+	}
+
+	private String createFileId() {
+		return UUID.randomUUID().toString();
+	}
+
+	private String createPath(String prefix, String fileName) {
+		String fileId = createFileId();
+		return String.format("%s/%s", prefix, fileId + "-" + fileName);
+	}
+}

--- a/packy-infra/src/main/java/com/dilly/global/S3Config.java
+++ b/packy-infra/src/main/java/com/dilly/global/S3Config.java
@@ -1,0 +1,39 @@
+package com.dilly.global;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+public class S3Config {
+
+	@Value("${cloud.aws.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${cloud.aws.credentials.secret-key}")
+	private String secretKey;
+
+	@Value("${cloud.aws.region}")
+	private String region;
+
+	@Bean
+	@Primary
+	public BasicAWSCredentials awsCredentialsProvider() {
+		BasicAWSCredentials basicAWSCredentials = new BasicAWSCredentials(accessKey, secretKey);
+		return basicAWSCredentials;
+	}
+
+	@Bean
+	public AmazonS3 amazonS3() {
+		return AmazonS3ClientBuilder.standard()
+			.withRegion(region)
+			.withCredentials(new AWSStaticCredentialsProvider(awsCredentialsProvider()))
+			.build();
+	}
+}

--- a/packy-infra/src/main/java/com/dilly/global/S3Config.java
+++ b/packy-infra/src/main/java/com/dilly/global/S3Config.java
@@ -25,8 +25,7 @@ public class S3Config {
 	@Bean
 	@Primary
 	public BasicAWSCredentials awsCredentialsProvider() {
-		BasicAWSCredentials basicAWSCredentials = new BasicAWSCredentials(accessKey, secretKey);
-		return basicAWSCredentials;
+		return new BasicAWSCredentials(accessKey, secretKey);
 	}
 
 	@Bean


### PR DESCRIPTION
## 🛰️ Issue Number
#41 

## 🪐 작업 내용
MultipartFile 업로드를 서버에서 담당하게 된다면 임시로 디스크에 파일을 저장해야 합니다. 해당 구현 방식은 다수의 사용자로부터 동시에 요청이 들어올 경우,서버의 스레드가 고갈되어 타임아웃으로 이어질 위험이 있습니다.
- 해당 문제를 보완하기 위해 Presigned URL을 사용하는 방식으로 파일 업로드를 구현하였습니다. 
  - Presigned URL을 사용할 경우 권한 부여를 통해 S3 보안에도 유리합니다.
  - 현재는 버킷을 퍼블릭으로 관리하고 있기 때문에 해당 이점은 챙기지 않고 있습니다. 하지만 추후 버킷 보안을 강화한다면 해당 이점 또한 챙길 수 있을 것입니다 :)

## 📚 Reference
https://leeeeeyeon-dev.tistory.com/88

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
