### PR TITLE
feat: 애플 소셜 로그인 기능 구현

### DIFF
--- a/packy-api/build.gradle
+++ b/packy-api/build.gradle
@@ -45,6 +45,10 @@ dependencies {
 
     // sentry
     implementation 'io.sentry:sentry-logback:6.26.0'
+
+    // apple login
+    implementation 'org.bouncycastle:bcprov-jdk15on:1.69'
+    implementation 'org.bouncycastle:bcpkix-jdk14:1.72'
 }
 
 test {

--- a/packy-api/src/main/java/com/dilly/auth/application/AppleService.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/AppleService.java
@@ -50,13 +50,13 @@ import lombok.extern.slf4j.Slf4j;
 public class AppleService {
 
 	@Value("${security.oauth2.provider.apple.audience-uri}")
-	private String APPLE_AUDIENCE_URI;
+	private String appleAudienceUri;
 	@Value("${security.oauth2.provider.apple.token-uri}")
-	private String APPLE_TOKEN_URI;
+	private String appleTokenUri;
 	@Value("${security.oauth2.provider.apple.key-uri}")
-	private String APPLE_KEY_URI;
+	private String appleKeyUri;
 	@Value("${security.oauth2.provider.apple.revoke-uri}")
-	private String APPLE_REVOKE_URI;
+	private String appleRevokeUri;
 	@Value("${spring.security.oauth2.provider.apple.team-id}")
 	private String appleTeamId;
 	@Value("${spring.security.oauth2.provider.apple.client-id}")
@@ -69,7 +69,7 @@ public class AppleService {
 	public AppleToken getAppleToken(String providerAccessToken) {
 		try {
 			WebClient webClient = WebClient.builder()
-				.baseUrl(APPLE_TOKEN_URI)
+				.baseUrl(appleTokenUri)
 				.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
 				.build();
 
@@ -92,7 +92,7 @@ public class AppleService {
 	public AppleAccountInfo getAppleAccountInfo(String idToken) {
 		try {
 			WebClient webClient = WebClient.builder()
-				.baseUrl(APPLE_KEY_URI)
+				.baseUrl(appleKeyUri)
 				.build();
 
 			ApplePublicKey applePublicKey = webClient.get()
@@ -143,7 +143,7 @@ public class AppleService {
 				.setIssuer(appleTeamId)
 				.setIssuedAt(new Date(System.currentTimeMillis()))
 				.setExpiration(expirationDate)
-				.setAudience(APPLE_AUDIENCE_URI)
+				.setAudience(appleAudienceUri)
 				.setSubject(appleClientId)
 				.signWith(getApplePrivateKey(), SignatureAlgorithm.ES256)
 				.compact();
@@ -172,7 +172,7 @@ public class AppleService {
 			String appleRefreshToken = appleAccount.getRefreshToken();
 
 			WebClient webClient = WebClient.builder()
-				.baseUrl(APPLE_REVOKE_URI)
+				.baseUrl(appleRevokeUri)
 				.build();
 
 			MultiValueMap<String, String> bodyData = new LinkedMultiValueMap<>();

--- a/packy-api/src/main/java/com/dilly/auth/application/AppleService.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/AppleService.java
@@ -57,13 +57,13 @@ public class AppleService {
 	private String appleKeyUri;
 	@Value("${security.oauth2.provider.apple.revoke-uri}")
 	private String appleRevokeUri;
-	@Value("${spring.security.oauth2.provider.apple.team-id}")
+	@Value("${security.oauth2.provider.apple.team-id}")
 	private String appleTeamId;
-	@Value("${spring.security.oauth2.provider.apple.client-id}")
+	@Value("${security.oauth2.provider.apple.client-id}")
 	private String appleClientId;
-	@Value("${spring.security.oauth2.provider.apple.key-id}")
+	@Value("${security.oauth2.provider.apple.key-id}")
 	private String appleKeyId;
-	@Value("${spring.security.oauth2.provider.apple.private-key}")
+	@Value("${security.oauth2.provider.apple.private-key}")
 	private String applePrivateKey;
 
 	public AppleToken getAppleToken(String providerAccessToken) {

--- a/packy-api/src/main/java/com/dilly/auth/application/AppleService.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/AppleService.java
@@ -1,0 +1,168 @@
+package com.dilly.auth.application;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Base64;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.dilly.auth.model.AppleAccountInfo;
+import com.dilly.auth.model.ApplePublicKey;
+import com.dilly.auth.model.ApplePublicKey.Key;
+import com.dilly.auth.model.AppleToken;
+import com.dilly.global.exception.InternalServerException;
+import com.dilly.global.response.ErrorCode;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class AppleService {
+
+	@Value("${security.oauth2.provider.apple.audience-uri}")
+	private String APPLE_AUDIENCE_URI;
+	@Value("${security.oauth2.provider.apple.token-uri}")
+	private String APPLE_TOKEN_URI;
+	@Value("${security.oauth2.provider.apple.key-uri}")
+	private String APPLE_KEY_URI;
+	@Value("${spring.security.oauth2.provider.apple.team-id}")
+	private String appleTeamId;
+	@Value("${spring.security.oauth2.provider.apple.client-id}")
+	private String appleClientId;
+	@Value("${spring.security.oauth2.provider.apple.key-id}")
+	private String appleKeyId;
+	@Value("${spring.security.oauth2.provider.apple.private-key}")
+	private String applePrivateKey;
+
+	public AppleToken getAppleToken(String providerAccessToken) {
+		try {
+			WebClient webClient = WebClient.builder()
+				.baseUrl(APPLE_TOKEN_URI)
+				.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+				.build();
+
+			MultiValueMap<String, String> bodyData = new LinkedMultiValueMap<>();
+			bodyData.add("client_id", appleClientId);
+			bodyData.add("client_secret", getAppleClientSecret());
+			bodyData.add("code", providerAccessToken);
+			bodyData.add("grant_type", "authorization_code");
+
+			return webClient.post()
+				.body(BodyInserters.fromFormData(bodyData))
+				.retrieve()
+				.bodyToMono(AppleToken.class)
+				.block();
+		} catch (Exception e) {
+			throw new InternalServerException(ErrorCode.APPLE_SERVER_ERROR);
+		}
+	}
+
+	public AppleAccountInfo getAppleAccountInfo(String idToken) {
+		try {
+			WebClient webClient = WebClient.builder()
+				.baseUrl(APPLE_KEY_URI)
+				.build();
+
+			ApplePublicKey applePublicKey = webClient.get()
+				.retrieve()
+				.bodyToMono(ApplePublicKey.class)
+				.block();
+
+			String headerOfIdToken = idToken.substring(0, idToken.indexOf("."));
+
+			Map<String, String> header = new ObjectMapper().readValue(
+				new String(Base64.getUrlDecoder().decode(headerOfIdToken), StandardCharsets.UTF_8),
+				Map.class
+			);
+			Key key = applePublicKey.getMatchedKeyBy(header.get("kid"), header.get("alg"))
+				.orElseThrow(() -> new NullPointerException("Apple ID 서버에서 공개키를 가져오지 못했습니다."));
+
+			byte[] nBytes = Base64.getUrlDecoder().decode(key.getN());
+			byte[] eBytes = Base64.getUrlDecoder().decode(key.getE());
+
+			BigInteger n = new BigInteger(1, nBytes);
+			BigInteger e = new BigInteger(1, eBytes);
+
+			RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(n, e);
+			KeyFactory keyFactory = KeyFactory.getInstance(key.getKty());
+			PublicKey publicKey = keyFactory.generatePublic(publicKeySpec);
+
+			Claims memberInfo = Jwts.parserBuilder().setSigningKey(publicKey).build().parseClaimsJws(idToken).getBody();
+
+			Map<String, Object> expectedMap = new HashMap<>(memberInfo);
+
+			return new ObjectMapper()
+				.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+				.convertValue(expectedMap, AppleAccountInfo.class);
+		} catch (Exception e) {
+			throw new InternalServerException(ErrorCode.APPLE_SERVER_ERROR);
+		}
+	}
+
+	private String getAppleClientSecret() {
+		Date expirationDate = Date.from(
+			LocalDateTime.now().plusDays(180).atZone(ZoneId.systemDefault()).toInstant()
+		);
+
+		try {
+			return Jwts.builder()
+				.setHeaderParam("kid", appleKeyId)
+				.setHeaderParam("alg", "ES256")
+				.setIssuer(appleTeamId)
+				.setIssuedAt(new Date(System.currentTimeMillis()))
+				.setExpiration(expirationDate)
+				.setAudience(APPLE_AUDIENCE_URI)
+				.setSubject(appleClientId)
+				.signWith(getApplePrivateKey(), SignatureAlgorithm.ES256)
+				.compact();
+		} catch (Exception e) {
+			throw new InternalServerException(ErrorCode.APPLE_SERVER_ERROR);
+		}
+	}
+
+	private PrivateKey getApplePrivateKey() {
+		try {
+			ClassPathResource resource = new ClassPathResource(applePrivateKey);
+			String privateKey = new String(resource.getInputStream().readAllBytes());
+			Reader pemReader = new StringReader(privateKey);
+			PEMParser pemParser = new PEMParser(pemReader);
+			JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
+			PrivateKeyInfo object = (PrivateKeyInfo)pemParser.readObject();
+
+			return converter.getPrivateKey(object);
+		} catch (Exception e) {
+			throw new InternalServerException(ErrorCode.APPLE_SERVER_ERROR);
+		}
+	}
+}

--- a/packy-api/src/main/java/com/dilly/auth/application/AppleService.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/AppleService.java
@@ -23,7 +23,6 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.BodyInserters;
@@ -47,7 +46,6 @@ import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 @Slf4j
 public class AppleService {
 

--- a/packy-api/src/main/java/com/dilly/auth/application/AuthService.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/AuthService.java
@@ -136,6 +136,12 @@ public class AuthService {
 				kakaoAccountWriter.delete(kakaoAccount);
 			}
 
+			case APPLE -> {
+				AppleAccount appleAccount = appleAccountReader.findByMember(member);
+				appleService.revokeAppleAccount(appleAccount);
+				appleAccountWriter.delete(appleAccount);
+			}
+
 			default -> throw new UnsupportedException(ErrorCode.UNSUPPORTED_LOGIN_TYPE);
 		}
 

--- a/packy-api/src/main/java/com/dilly/auth/application/AuthService.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/AuthService.java
@@ -100,6 +100,12 @@ public class AuthService {
 				member = kakaoAccountReader.getMemberById(kakaoResource.getId());
 			}
 
+			case "apple" -> {
+				AppleToken appleToken = appleService.getAppleToken(providerAccessToken);
+				AppleAccountInfo appleAccountInfo = appleService.getAppleAccountInfo(appleToken.idToken());
+				member = appleAccountReader.getMemberById(appleAccountInfo.sub());
+			}
+
 			default -> throw new UnsupportedException(ErrorCode.UNSUPPORTED_LOGIN_TYPE);
 		}
 

--- a/packy-api/src/main/java/com/dilly/auth/application/KakaoService.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/KakaoService.java
@@ -34,21 +34,21 @@ import lombok.extern.slf4j.Slf4j;
 public class KakaoService {
 
 	@Value("${security.oauth2.provider.kakao.token-uri}")
-	private String KAKAO_TOKEN_URI;
+	private String kakaoTokenUri;
 	@Value("${security.oauth2.provider.kakao.user-info-uri}")
-	private String KAKAO_USER_INFO_URI;
+	private String kakaoUserInfoUri;
 	@Value("${security.oauth2.provider.kakao.unlink-uri}")
-	private String KAKAO_UNLINK_URI;
+	private String kakaoUnlinkUri;
 	@Value("${security.oauth2.provider.kakao.client-id}")
-	private String KAKAO_CLIENT_ID;
+	private String kakaoClientId;
 	@Value("${security.oauth2.provider.kakao.admin-key}")
-	private String KAKAO_ADMIN_KEY;
-	private String BEARER_PREFIX = "Bearer ";
+	private String kakaoAdminKey;
+	private final String bearerPrefix = "Bearer ";
 
 	public KakaoResource getKaKaoAccount(String kakaoAccessToken) {
 		WebClient webClient = WebClient.builder()
-			.baseUrl(KAKAO_USER_INFO_URI)
-			.defaultHeader(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + kakaoAccessToken)
+			.baseUrl(kakaoUserInfoUri)
+			.defaultHeader(HttpHeaders.AUTHORIZATION, bearerPrefix + kakaoAccessToken)
 			.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
 			.build();
 
@@ -66,7 +66,7 @@ public class KakaoService {
 		String access_Token = "";
 
 		try {
-			URL url = new URL(KakaoService.this.KAKAO_TOKEN_URI);
+			URL url = new URL(KakaoService.this.kakaoTokenUri);
 			HttpURLConnection conn = (HttpURLConnection)url.openConnection();
 
 			conn.setRequestMethod("POST");
@@ -76,7 +76,7 @@ public class KakaoService {
 			StringBuilder sb = new StringBuilder();
 			sb.append("grant_type=authorization_code")
 				.append("&client_id=")
-				.append(KAKAO_CLIENT_ID)
+				.append(kakaoClientId)
 				.append("&redirect_uri=http://127.0.0.1:9000/kakaocallback")
 				.append("&code=" + code);
 			bw.write(sb.toString());
@@ -102,8 +102,8 @@ public class KakaoService {
 
 	public void unlinkKakaoAccount(KakaoAccount kakaoAccount) {
 		WebClient webClient = WebClient.builder()
-			.baseUrl(KAKAO_UNLINK_URI)
-			.defaultHeader(HttpHeaders.AUTHORIZATION, "KakaoAK " + KAKAO_ADMIN_KEY)
+			.baseUrl(kakaoUnlinkUri)
+			.defaultHeader(HttpHeaders.AUTHORIZATION, "KakaoAK " + kakaoAdminKey)
 			.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
 			.build();
 

--- a/packy-api/src/main/java/com/dilly/auth/application/KakaoService.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/KakaoService.java
@@ -79,10 +79,11 @@ public class KakaoService {
 
 			BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream()));
 			StringBuilder sb = new StringBuilder();
-			sb.append("grant_type=authorization_code");
-			sb.append("&client_id=" + KAKAO_CLIENT_ID);
-			sb.append("&redirect_uri=http://127.0.0.1:9000/kakaocallback");
-			sb.append("&code=" + code);
+			sb.append("grant_type=authorization_code")
+				.append("&client_id=")
+				.append(KAKAO_CLIENT_ID)
+				.append("&redirect_uri=http://127.0.0.1:9000/kakaocallback")
+				.append("&code=" + code);
 			bw.write(sb.toString());
 			bw.flush();
 

--- a/packy-api/src/main/java/com/dilly/auth/application/KakaoService.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/KakaoService.java
@@ -12,7 +12,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.BodyInserters;
@@ -31,7 +30,6 @@ import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 @Slf4j
 public class KakaoService {
 

--- a/packy-api/src/main/java/com/dilly/auth/application/KakaoService.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/KakaoService.java
@@ -20,7 +20,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientException;
 
 import com.dilly.auth.KakaoAccount;
-import com.dilly.auth.domain.KakaoAccountReader;
 import com.dilly.auth.model.KakaoResource;
 import com.dilly.global.exception.InternalServerException;
 import com.dilly.global.response.ErrorCode;
@@ -35,8 +34,6 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional
 @Slf4j
 public class KakaoService {
-
-	private final KakaoAccountReader kakaoAccountReader;
 
 	@Value("${security.oauth2.provider.kakao.token-uri}")
 	private String KAKAO_TOKEN_URI;

--- a/packy-api/src/main/java/com/dilly/auth/application/KakaoService.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/KakaoService.java
@@ -43,9 +43,9 @@ public class KakaoService {
 	private String kakaoClientId;
 	@Value("${security.oauth2.provider.kakao.admin-key}")
 	private String kakaoAdminKey;
-	private final String bearerPrefix = "Bearer ";
 
 	public KakaoResource getKaKaoAccount(String kakaoAccessToken) {
+		String bearerPrefix = "Bearer ";
 		WebClient webClient = WebClient.builder()
 			.baseUrl(kakaoUserInfoUri)
 			.defaultHeader(HttpHeaders.AUTHORIZATION, bearerPrefix + kakaoAccessToken)

--- a/packy-api/src/main/java/com/dilly/auth/domain/AppleAccountReader.java
+++ b/packy-api/src/main/java/com/dilly/auth/domain/AppleAccountReader.java
@@ -18,4 +18,7 @@ public class AppleAccountReader {
 			throw new MemberAlreadyExistException();
 		}
 	}
+	public Optional<Member> getMemberById(String sub) {
+		return appleAccountRepository.findById(sub).map(AppleAccount::getMember);
+	}
 }

--- a/packy-api/src/main/java/com/dilly/auth/domain/AppleAccountReader.java
+++ b/packy-api/src/main/java/com/dilly/auth/domain/AppleAccountReader.java
@@ -1,0 +1,21 @@
+package com.dilly.auth.domain;
+
+import org.springframework.stereotype.Component;
+
+import com.dilly.auth.AppleAccountRepository;
+import com.dilly.global.exception.alreadyexist.MemberAlreadyExistException;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AppleAccountReader {
+
+	private final AppleAccountRepository appleAccountRepository;
+
+	public void isAppleAccountPresent(String sub) {
+		if (appleAccountRepository.findById(sub).isPresent()) {
+			throw new MemberAlreadyExistException();
+		}
+	}
+}

--- a/packy-api/src/main/java/com/dilly/auth/domain/AppleAccountReader.java
+++ b/packy-api/src/main/java/com/dilly/auth/domain/AppleAccountReader.java
@@ -1,9 +1,13 @@
 package com.dilly.auth.domain;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Component;
 
+import com.dilly.auth.AppleAccount;
 import com.dilly.auth.AppleAccountRepository;
 import com.dilly.global.exception.alreadyexist.MemberAlreadyExistException;
+import com.dilly.member.Member;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,7 +22,12 @@ public class AppleAccountReader {
 			throw new MemberAlreadyExistException();
 		}
 	}
+
 	public Optional<Member> getMemberById(String sub) {
 		return appleAccountRepository.findById(sub).map(AppleAccount::getMember);
+	}
+
+	public AppleAccount findByMember(Member member) {
+		return appleAccountRepository.findByMember(member);
 	}
 }

--- a/packy-api/src/main/java/com/dilly/auth/domain/AppleAccountWriter.java
+++ b/packy-api/src/main/java/com/dilly/auth/domain/AppleAccountWriter.java
@@ -16,4 +16,8 @@ public class AppleAccountWriter {
 	public void save(AppleAccount appleAccount) {
 		appleAccountRepository.save(appleAccount);
 	}
+
+	public void delete(AppleAccount appleAccount) {
+		appleAccountRepository.delete(appleAccount);
+	}
 }

--- a/packy-api/src/main/java/com/dilly/auth/domain/AppleAccountWriter.java
+++ b/packy-api/src/main/java/com/dilly/auth/domain/AppleAccountWriter.java
@@ -1,0 +1,19 @@
+package com.dilly.auth.domain;
+
+import org.springframework.stereotype.Component;
+
+import com.dilly.auth.AppleAccount;
+import com.dilly.auth.AppleAccountRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AppleAccountWriter {
+
+	private final AppleAccountRepository appleAccountRepository;
+
+	public void save(AppleAccount appleAccount) {
+		appleAccountRepository.save(appleAccount);
+	}
+}

--- a/packy-api/src/main/java/com/dilly/auth/model/AppleAccountInfo.java
+++ b/packy-api/src/main/java/com/dilly/auth/model/AppleAccountInfo.java
@@ -1,0 +1,24 @@
+package com.dilly.auth.model;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.*;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonInclude(NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record AppleAccountInfo(
+	String iss,
+	String exp,
+	String iat,
+	String sub,
+	String atHash,
+	String email,
+	Boolean emailVerified,
+	Boolean isEmail,
+	String authTime,
+	Boolean nonceSupported
+) {
+
+}

--- a/packy-api/src/main/java/com/dilly/auth/model/ApplePublicKey.java
+++ b/packy-api/src/main/java/com/dilly/auth/model/ApplePublicKey.java
@@ -1,0 +1,34 @@
+package com.dilly.auth.model;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.*;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Getter;
+
+@JsonInclude(NON_NULL)
+public class ApplePublicKey {
+
+	ArrayList<Key> keys;
+
+	@Getter
+	@JsonInclude(NON_NULL)
+	public static class Key {
+
+		String kty;
+		String kid;
+		String use;
+		String alg;
+		String n;
+		String e;
+	}
+
+	public Optional<Key> getMatchedKeyBy(String kid, String alg) {
+		return this.keys.stream()
+			.filter(key -> key.kid.equals(kid) && key.alg.equals(alg))
+			.findFirst();
+	}
+}

--- a/packy-api/src/main/java/com/dilly/auth/model/AppleToken.java
+++ b/packy-api/src/main/java/com/dilly/auth/model/AppleToken.java
@@ -3,8 +3,11 @@ package com.dilly.auth.model;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.*;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonInclude(NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record AppleToken(
 	String accessToken,
 	String refreshToken,

--- a/packy-api/src/main/java/com/dilly/auth/model/AppleToken.java
+++ b/packy-api/src/main/java/com/dilly/auth/model/AppleToken.java
@@ -1,0 +1,13 @@
+package com.dilly.auth.model;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.*;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(NON_NULL)
+public record AppleToken(
+	String accessToken,
+	String refreshToken,
+	String idToken
+) {
+}

--- a/packy-api/src/main/java/com/dilly/global/response/ErrorCode.java
+++ b/packy-api/src/main/java/com/dilly/global/response/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
 	INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 오류가 발생했습니다."),
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP Method 요청입니다."),
 	KAKAO_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 서버 연동에 오류가 발생했습니다."),
+	APPLE_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "애플 서버 연동에 오류가 발생했습니다."),
 	API_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 API를 찾을 수 없습니다."),
 
 	// Authorization

--- a/packy-api/src/test/resources/application-test.yml
+++ b/packy-api/src/test/resources/application-test.yml
@@ -21,7 +21,7 @@ spring:
 
   flyway:
     enabled: false
-    
+
 security:
   oauth2:
     provider:
@@ -33,6 +33,10 @@ security:
         client-id: test
         admin-key: test
       apple:
+        audience-uri: test
+        token-uri: test
+        key-uri: test
+        revoke-uri: test
         team-id: test
         client-id: test
         key-id: test

--- a/packy-domain/src/main/java/com/dilly/auth/AppleAccount.java
+++ b/packy-domain/src/main/java/com/dilly/auth/AppleAccount.java
@@ -1,0 +1,30 @@
+package com.dilly.auth;
+
+import com.dilly.global.BaseTimeEntity;
+import com.dilly.member.Member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AppleAccount extends BaseTimeEntity {
+
+	@Id
+	private String id;
+
+	@Column(nullable = false)
+	private String refreshToken;
+
+	@OneToOne
+	@JoinColumn
+	private Member member;
+}

--- a/packy-domain/src/main/java/com/dilly/auth/AppleAccount.java
+++ b/packy-domain/src/main/java/com/dilly/auth/AppleAccount.java
@@ -10,9 +10,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/packy-domain/src/main/java/com/dilly/auth/AppleAccountRepository.java
+++ b/packy-domain/src/main/java/com/dilly/auth/AppleAccountRepository.java
@@ -2,5 +2,9 @@ package com.dilly.auth;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.dilly.member.Member;
+
 public interface AppleAccountRepository extends JpaRepository<AppleAccount, String> {
+
+	AppleAccount findByMember(Member member);
 }

--- a/packy-domain/src/main/java/com/dilly/auth/AppleAccountRepository.java
+++ b/packy-domain/src/main/java/com/dilly/auth/AppleAccountRepository.java
@@ -1,0 +1,6 @@
+package com.dilly.auth;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AppleAccountRepository extends JpaRepository<AppleAccount, String> {
+}

--- a/packy-domain/src/main/resources/db/migration/V3__add_apple_account.sql
+++ b/packy-domain/src/main/resources/db/migration/V3__add_apple_account.sql
@@ -1,0 +1,13 @@
+create table apple_account
+(
+    created_at    datetime(6)  null,
+    member_id     bigint       null,
+    updated_at    datetime(6)  null,
+    id            varchar(255) not null
+        primary key,
+    refresh_token varchar(255) not null,
+    constraint UK_dgjlx80xq0hvlqlrolg0nxfbl
+        unique (member_id),
+    constraint FKjp63nbe4doslyu7tfmv57nb71
+        foreign key (member_id) references member (id)
+);


### PR DESCRIPTION
## 🛰️ Issue Number
#6 

## 🪐 작업 내용
- 애플 회원가입, 애플 로그인, 애플 회원탈퇴 기능을 구현하였습니다.

### 🤔 고민되는 점
AppleService와 KakaoService 클래스는 DB에 접근하지 않으며, 외부 API(카카오, 애플)과 통신하여 알맞은 모델 클래스를 주고받는 역할만 하고 있습니다.
1. 해당 클래스를 Service라고 칭하는 것이 맞을까?
2. api 모듈보다는 infra 모듈이나 clients 모듈에 적합하지 않을까?
  a. 현재 예외 클래스와 코드를 api 모듈에서 관리하고 있기 때문에 모듈 간 의존 관계에 문제가 발생

## 📚 Reference
- https://velog.io/@haron/Spring-%EC%95%A0%ED%94%8C-%EB%A1%9C%EA%B7%B8%EC%9D%B8%EC%9D%84-%EA%B5%AC%ED%98%84%ED%95%B4%EB%B3%B4%EC%9E%90
- https://shxrecord.tistory.com/289
- https://kedric-me.tistory.com/entry/JAVA-%EC%95%A0%ED%94%8C-%EC%97%B0%EB%8F%99%ED%95%B4%EC%A0%9C-%EA%B5%AC%ED%98%84-Sign-Out-of-Apple-ID

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
