### PR TITLE
fix: 애플로그인 예외 처리 세분화

### DIFF
--- a/db.vuerd.json
+++ b/db.vuerd.json
@@ -467,7 +467,7 @@
             "id": "1f0095df-47d9-44ee-9992-1d5cf1102126",
             "name": "id",
             "comment": "UUID",
-            "dataType": "BIGINT",
+            "dataType": "VARCHAR",
             "default": "",
             "option": {
               "autoIncrement": false,
@@ -1036,9 +1036,9 @@
         ],
         "ui": {
           "active": false,
-          "left": 1563.5056,
-          "top": 650.6032,
-          "zIndex": 12,
+          "left": 1555.5056,
+          "top": 589.6032,
+          "zIndex": 4,
           "widthName": 66.36289978027344,
           "widthComment": 60
         },
@@ -1231,7 +1231,7 @@
           "active": false,
           "left": 93.5,
           "top": 63,
-          "zIndex": 1,
+          "zIndex": 6,
           "widthName": 60,
           "widthComment": 72.88896179199219
         },
@@ -1855,8 +1855,8 @@
           "columnIds": [
             "151107b9-e942-47df-97dd-8b5de5918ce9"
           ],
-          "x": 1678.687440979004,
-          "y": 544.0784,
+          "x": 1744.2339650268555,
+          "y": 429.0784,
           "direction": "bottom"
         },
         "constraintName": "fk_envelope_to_letter",

--- a/packy-api/src/main/java/com/dilly/auth/application/KakaoService.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/KakaoService.java
@@ -20,7 +20,7 @@ import org.springframework.web.reactive.function.client.WebClientException;
 
 import com.dilly.auth.KakaoAccount;
 import com.dilly.auth.model.KakaoResource;
-import com.dilly.global.exception.InternalServerException;
+import com.dilly.global.exception.internalserver.InternalServerException;
 import com.dilly.global.response.ErrorCode;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;

--- a/packy-api/src/main/java/com/dilly/global/exception/internalserver/AppleServerException.java
+++ b/packy-api/src/main/java/com/dilly/global/exception/internalserver/AppleServerException.java
@@ -1,0 +1,16 @@
+package com.dilly.global.exception.internalserver;
+
+import static com.dilly.global.response.ErrorCode.*;
+
+import com.dilly.global.response.ErrorCode;
+
+public class AppleServerException extends InternalServerException {
+
+	public AppleServerException() {
+		super(APPLE_SERVER_ERROR);
+	}
+
+	public AppleServerException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/packy-api/src/main/java/com/dilly/global/exception/internalserver/InternalServerException.java
+++ b/packy-api/src/main/java/com/dilly/global/exception/internalserver/InternalServerException.java
@@ -1,5 +1,6 @@
-package com.dilly.global.exception;
+package com.dilly.global.exception.internalserver;
 
+import com.dilly.global.exception.BusinessException;
 import com.dilly.global.response.ErrorCode;
 
 public class InternalServerException extends BusinessException {

--- a/packy-api/src/main/java/com/dilly/global/response/ErrorCode.java
+++ b/packy-api/src/main/java/com/dilly/global/response/ErrorCode.java
@@ -18,9 +18,14 @@ public enum ErrorCode {
 	// Internal Server Error
 	INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 오류가 발생했습니다."),
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP Method 요청입니다."),
+	API_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 API를 찾을 수 없습니다."),
 	KAKAO_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 서버 연동에 오류가 발생했습니다."),
 	APPLE_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "애플 서버 연동에 오류가 발생했습니다."),
-	API_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 API를 찾을 수 없습니다."),
+	APPLE_FAILED_TO_GET_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "애플 토큰을 가져오는데 실패했습니다."),
+	APPLE_FAILED_TO_GET_PUBLIC_KEY(HttpStatus.INTERNAL_SERVER_ERROR, "애플 공개키를 가져오는데 실패했습니다."),
+	APPLE_FAILED_TO_GET_INFO(HttpStatus.INTERNAL_SERVER_ERROR, "애플 계정 정보를 가져오는데 실패했습니다."),
+	APPLE_FAILED_TO_GET_CLIENT_SECRET(HttpStatus.INTERNAL_SERVER_ERROR, "애플 client_secret을 가져오는데 실패했습니다."),
+	APPLE_FAILED_TO_REVOKE_ACCOUNT(HttpStatus.INTERNAL_SERVER_ERROR, "애플 계정을 해지하는데 실패했습니다."),
 
 	// Authorization
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),


### PR DESCRIPTION
## 🛰️ Issue Number
#57

## 🪐 작업 내용
getAppleAccountInfo은 WebClient로 외부 통신을 하고, 키를 복호화하여 유저 정보를 가져오는 파트로 나누어져 있습니다.
어느 부분에서 에러가 났는지 파악하기 위해 예외 처리를 세분화하여 각 파트를 try-catch문으로 분리했습니다.

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [ ] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
