### PR TITLE
fix: Public Key를 가져오지 못하는 문제 해결

### DIFF
--- a/.github/workflows/packy-cd.yml
+++ b/.github/workflows/packy-cd.yml
@@ -55,7 +55,7 @@ jobs:
           cd deploy && zip -r deploy.zip .
 
       - name: Beanstalk Deploy
-        uses: einaregilsson/beanstalk-deploy@v14
+        uses: einaregilsson/beanstalk-deploy@v16
         with:
           aws_access_key: ${{ secrets.AWS_ACCESS_KEY }}
           aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/packy-api/src/main/java/com/dilly/auth/application/AppleService.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/AppleService.java
@@ -92,6 +92,8 @@ public class AppleService {
 	}
 
 	public AppleAccountInfo getAppleAccountInfo(String idToken) {
+		log.error("idToken: {}", idToken);
+
 		ApplePublicKey applePublicKey;
 		try {
 			WebClient webClient = WebClient.builder()

--- a/packy-api/src/main/java/com/dilly/auth/application/AppleService.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/AppleService.java
@@ -140,7 +140,7 @@ public class AppleService {
 
 	private String getAppleClientSecret() {
 		Date expirationDate = Date.from(
-			LocalDateTime.now().plusDays(180).atZone(ZoneId.systemDefault()).toInstant()
+			LocalDateTime.now().plusDays(30).atZone(ZoneId.systemDefault()).toInstant()
 		);
 
 		try {

--- a/packy-api/src/main/java/com/dilly/auth/application/AppleService.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/AppleService.java
@@ -92,8 +92,6 @@ public class AppleService {
 	}
 
 	public AppleAccountInfo getAppleAccountInfo(String idToken) {
-		log.error("idToken: {}", idToken);
-
 		ApplePublicKey applePublicKey;
 		try {
 			WebClient webClient = WebClient.builder()

--- a/packy-api/src/main/java/com/dilly/auth/model/ApplePublicKey.java
+++ b/packy-api/src/main/java/com/dilly/auth/model/ApplePublicKey.java
@@ -1,21 +1,19 @@
 package com.dilly.auth.model;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.*;
-
 import java.util.ArrayList;
 import java.util.Optional;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-
 import lombok.Getter;
+import lombok.ToString;
 
-@JsonInclude(NON_NULL)
+@Getter
+@ToString
 public class ApplePublicKey {
 
 	ArrayList<Key> keys;
 
 	@Getter
-	@JsonInclude(NON_NULL)
+	@ToString
 	public static class Key {
 
 		String kty;


### PR DESCRIPTION
## 🛰️ Issue Number
#57 

## 🪐 작업 내용
- 디버깅을 통해 https://appleid.apple.com/auth/keys 에서 Public Key 정보를 가져오지 못해 ApplePublicKey 클래스가 null이 된다는 것을 확인했습니다.
  -  ToString 어노테이션을 추가하여 객체에 정보가 담길 수 있도록 해결하였습니다.
- 부가적인 작업
  - client_secret이 180일로 애플에서 허용하는 최댓값으로 설정되어 있어 30일로 줄였습니다.
  - Github Actions에서 아래와 같은 Warning이 발생하여 einaregilsson/beanstalk-deploy의 버전을 16으로 업데이트해주었습니다.
> The following actions uses node12 which is deprecated and will be forced to run on node16: einaregilsson/beanstalk-deploy@v14. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
