### PR TITLE
setting: QueryDsl 환경 세팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ packy-api/src/test/resources/*.sql
 packy-domain/src/main/resources/*.yml
 packy-domain/src/main/resources/*.sql
 packy-infra/src/main/resources/*.yml
+
+### QueryDsl QClass ###
+packy-domain/src/main/generated

--- a/packy-api/build.gradle
+++ b/packy-api/build.gradle
@@ -16,8 +16,8 @@ dependencies {
     implementation project(':packy-domain')
     implementation project(':packy-infra')
 
-    testImplementation platform('org.junit:junit-bom:5.9.1')
-    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/packy-domain/build.gradle
+++ b/packy-domain/build.gradle
@@ -25,10 +25,27 @@ dependencies {
 
     // flyway
     implementation 'org.flywaydb:flyway-mysql'
+
+    // querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 test {
     useJUnitPlatform()
+}
+
+// querydsl
+def querydslSrcDir = 'src/main/generated'
+
+clean {
+    delete file(querydslSrcDir)
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.generatedSourceOutputDirectory = file(querydslSrcDir)
 }
 
 processResources.dependsOn('copySecret')

--- a/packy-domain/src/main/java/com/dilly/global/config/QueryDslConfig.java
+++ b/packy-domain/src/main/java/com/dilly/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.dilly.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
#63 

## 🪐 작업 내용
- QueryDsl 의존성을 추가했습니다.
- QClass가 생성되는 디렉토리를 gitignore에 추가했습니다.
- QueryDslConfig 클래스를 추가했습니다.

### 부가 작업
gradle 빌드를 하다가 아래와 같이 jupiter 의존성 주입하는 코드가 deprecated된다고 하여 해당 부분을 수정해주었습니다.

> The automatic loading of test framework implementation dependencies has been deprecated. This is scheduled to be removed in Gradle 9.0. Declare the desired test framework directly on the test suite or explicitly declare the test framework implementation dependencies on the test's runtime classpath. Consult the upgrading guide for further information: https://docs.gradle.org/8.5/userguide/upgrading_version_8.html#test_framework_implementation_dependencies

## 📚 Reference
- https://docs.gradle.org/8.5/userguide/upgrading_version_8.html#test_framework_implementation_dependencies

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
