### PR TITLE
style: giftRequest의 imgUrl을 url로 변수 이름 변경

### DIFF
--- a/packy-api/src/main/java/com/dilly/auth/api/AuthController.java
+++ b/packy-api/src/main/java/com/dilly/auth/api/AuthController.java
@@ -1,5 +1,17 @@
 package com.dilly.auth.api;
 
+import com.dilly.auth.application.AuthService;
+import com.dilly.auth.application.KakaoService;
+import com.dilly.auth.dto.request.SignupRequest;
+import com.dilly.auth.dto.response.SignInResponse;
+import com.dilly.global.response.DataResponseDto;
+import com.dilly.jwt.JwtService;
+import com.dilly.jwt.dto.JwtRequest;
+import com.dilly.jwt.dto.JwtResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -9,61 +21,47 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.dilly.auth.application.AuthService;
-import com.dilly.auth.application.KakaoService;
-import com.dilly.auth.dto.request.SignupRequest;
-import com.dilly.auth.dto.response.SignInResponse;
-import com.dilly.global.response.DataResponseDto;
-import com.dilly.jwt.JwtService;
-import com.dilly.jwt.dto.JwtRequest;
-import com.dilly.jwt.dto.JwtResponse;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-
 @Tag(name = "OAuth 관련 API")
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
 public class AuthController {
 
-	private final AuthService authService;
-	private final JwtService jwtService;
-	private final KakaoService kakaoService;
+    private final AuthService authService;
+    private final JwtService jwtService;
+    private final KakaoService kakaoService;
 
-	@Operation(summary = "회원 가입", description = "provider는 kakao 또는 apple")
-	@PostMapping("/sign-up")
-	public DataResponseDto<JwtResponse> signUp(
-		@RequestHeader("Authorization") @Schema(description = "Bearer prefix 제외해주세요") String providerAccessToken,
-		@RequestBody SignupRequest signupRequest) {
-		return DataResponseDto.from(authService.signUp(providerAccessToken, signupRequest));
-	}
+    @Operation(summary = "회원 가입", description = "provider는 kakao 또는 apple")
+    @PostMapping("/sign-up")
+    public DataResponseDto<JwtResponse> signUp(
+        @RequestHeader("Authorization") @Schema(description = "Bearer prefix 제외해주세요") String providerAccessToken,
+        @RequestBody SignupRequest signupRequest) {
+        return DataResponseDto.from(authService.signUp(providerAccessToken, signupRequest));
+    }
 
-	@Operation(summary = "로그인", description = "status는 NOT_REGISTERED, REGISTERED, WITHDRAWAL, BLACKLIST")
-	@GetMapping("/sign-in/{provider}")
-	public DataResponseDto<SignInResponse> signIn(
-		@PathVariable(name = "provider") @Schema(description = "kakao 또는 apple") String provider,
-		@RequestHeader("Authorization") String providerAccessToken) {
-		return DataResponseDto.from(authService.signIn(provider, providerAccessToken));
-	}
+    @Operation(summary = "로그인", description = "status는 NOT_REGISTERED, REGISTERED, WITHDRAWAL, BLACKLIST")
+    @GetMapping("/sign-in/{provider}")
+    public DataResponseDto<SignInResponse> signIn(
+        @PathVariable(name = "provider") @Schema(description = "kakao 또는 apple") String provider,
+        @RequestHeader("Authorization") String providerAccessToken) {
+        return DataResponseDto.from(authService.signIn(provider, providerAccessToken));
+    }
 
-	@Operation(summary = "회원 탈퇴")
-	@DeleteMapping("/withdraw")
-	public DataResponseDto<String> withdraw() {
-		return DataResponseDto.from(authService.withdraw());
-	}
+    @Operation(summary = "회원 탈퇴")
+    @DeleteMapping("/withdraw")
+    public DataResponseDto<String> withdraw() {
+        return DataResponseDto.from(authService.withdraw());
+    }
 
-	@Operation(summary = "JWT 만료 시 재발급")
-	@PostMapping("/reissue")
-	public DataResponseDto<JwtResponse> reissue(@RequestBody JwtRequest jwtRequest) {
-		return DataResponseDto.from(jwtService.reissueJwt(jwtRequest));
-	}
+    @Operation(summary = "JWT 만료 시 재발급")
+    @PostMapping("/reissue")
+    public DataResponseDto<JwtResponse> reissue(@RequestBody JwtRequest jwtRequest) {
+        return DataResponseDto.from(jwtService.reissueJwt(jwtRequest));
+    }
 
-	@Operation(summary = "카카오 토큰으로 정보 조회")
-	@GetMapping("/token/kakao/{code}")
-	public DataResponseDto<String> getKakaoAccessToken(@PathVariable(name = "code") String code) {
-		return DataResponseDto.from(kakaoService.getKakaoAccessToken(code));
-	}
+    @Operation(summary = "카카오 토큰으로 정보 조회", description = "서버에서 테스트용으로 사용하는 API입니다.")
+    @GetMapping("/token/kakao/{code}")
+    public DataResponseDto<String> getKakaoAccessToken(@PathVariable(name = "code") String code) {
+        return DataResponseDto.from(kakaoService.getKakaoAccessToken(code));
+    }
 }

--- a/packy-api/src/main/java/com/dilly/gift/application/GiftService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftService.java
@@ -45,7 +45,7 @@ public class GiftService {
         Letter letter = letterWriter.save(giftBoxRequest.letterContent(), envelope);
         Gift gift = Gift.builder()
             .giftType(GiftType.valueOf(giftBoxRequest.gift().type().toUpperCase()))
-            .giftUrl(giftBoxRequest.gift().imgUrl())
+            .giftUrl(giftBoxRequest.gift().url())
             .build();
 
         GiftBox giftBox = giftBoxWriter.save(box, letter, giftBoxRequest.youtubeUrl(), gift);

--- a/packy-api/src/main/java/com/dilly/gift/dto/request/GiftRequest.java
+++ b/packy-api/src/main/java/com/dilly/gift/dto/request/GiftRequest.java
@@ -8,7 +8,7 @@ public record GiftRequest(
     @Schema(example = "photo")
     String type,
     @Schema(example = "www.example.com")
-    String imgUrl
+    String url
 ) {
 
 }

--- a/packy-api/src/test/java/com/dilly/gift/api/GiftControllerTest.java
+++ b/packy-api/src/test/java/com/dilly/gift/api/GiftControllerTest.java
@@ -45,7 +45,7 @@ class GiftControllerTest extends ControllerTestSupport {
             )
             .gift(GiftRequest.builder()
                 .type("photo")
-                .imgUrl("www.naver.com")
+                .url("www.naver.com")
                 .build()
             )
             .build();

--- a/packy-api/src/test/java/com/dilly/gift/application/GiftServiceTest.java
+++ b/packy-api/src/test/java/com/dilly/gift/application/GiftServiceTest.java
@@ -51,7 +51,7 @@ class GiftServiceTest extends IntegrationTestSupport {
             )
             .gift(GiftRequest.builder()
                 .type("photo")
-                .imgUrl("www.naver.com")
+                .url("www.naver.com")
                 .build()
             )
             .build();
@@ -71,7 +71,7 @@ class GiftServiceTest extends IntegrationTestSupport {
         assertThat(giftBox.getYoutubeUrl()).isEqualTo(giftBoxRequest.youtubeUrl());
         assertThat(giftBox.getGift().getGiftType().name()).isEqualTo(
             giftBoxRequest.gift().type().toUpperCase());
-        assertThat(giftBox.getGift().getGiftUrl()).isEqualTo(giftBoxRequest.gift().imgUrl());
+        assertThat(giftBox.getGift().getGiftUrl()).isEqualTo(giftBoxRequest.gift().url());
         assertThat(photos).hasSize(2)
             .extracting("imgUrl", "description", "sequence")
             .contains(tuple("www.test1.com", "description1", 1),


### PR DESCRIPTION
## 🛰️ Issue Number
#41 

## 🪐 작업 내용
추후 사진이 아닌 것이 선물로 들어올 수 있을 때의 확장성을 고려하여 imgUrl 컬럼의 이름을 url로 변경하였습니다.

### 부가 작업
- 스웨거에서 서버에서만 사용하는 API를 구분할 수 있도록 설명을 추가하였습니다.

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
