### PR TITLE
feat: Spring Security, JWT 관련 설정 추가

### DIFF
--- a/packy-api/src/main/java/com/dilly/auth/application/AuthService.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/AuthService.java
@@ -1,11 +1,8 @@
 package com.dilly.auth.application;
 
-import static com.dilly.member.Provider.*;
-
-import java.util.Optional;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import static com.dilly.member.Provider.APPLE;
+import static com.dilly.member.Provider.KAKAO;
+import static com.dilly.member.Provider.TEST;
 
 import com.dilly.auth.AppleAccount;
 import com.dilly.auth.KakaoAccount;
@@ -33,9 +30,11 @@ import com.dilly.member.Status;
 import com.dilly.member.domain.MemberReader;
 import com.dilly.member.domain.MemberWriter;
 import com.dilly.member.domain.ProfileImageReader;
-
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -84,6 +83,11 @@ public class AuthService {
 					.refreshToken(appleToken.refreshToken())
 					.build()
 				);
+			}
+
+			case "test" -> {
+				provider = TEST;
+				member = memberWriter.save(signupRequest.toEntity(provider, profileImage));
 			}
 
 			default -> throw new UnsupportedException(ErrorCode.UNSUPPORTED_LOGIN_TYPE);

--- a/packy-api/src/main/java/com/dilly/global/config/SecurityConfig.java
+++ b/packy-api/src/main/java/com/dilly/global/config/SecurityConfig.java
@@ -1,5 +1,10 @@
 package com.dilly.global.config;
 
+import com.dilly.jwt.JwtAccessDeniedHandler;
+import com.dilly.jwt.JwtAuthenticationEntryPoint;
+import com.dilly.jwt.JwtFilter;
+import com.dilly.jwt.TokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -11,13 +16,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-
-import com.dilly.jwt.JwtAccessDeniedHandler;
-import com.dilly.jwt.JwtAuthenticationEntryPoint;
-import com.dilly.jwt.JwtFilter;
-import com.dilly.jwt.TokenProvider;
-
-import lombok.RequiredArgsConstructor;
 
 @Configuration
 @RequiredArgsConstructor
@@ -59,8 +57,16 @@ public class SecurityConfig {
 			// 토큰이 없는 상태에서 요청이 가능한 API는 permitAll 설정
 			.authorizeHttpRequests(authorizeRequests ->
 				authorizeRequests
-					// TODO: permitAll() 범위 수정
-					.requestMatchers("/**").permitAll()
+					.requestMatchers("/", "/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**")
+					.permitAll()
+					.requestMatchers(
+						"/api/v1/admin/health",
+						"/api/v1/auth/token/kakao/**",
+						"/api/v1/admin/design/profiles",
+						"/api/v1/auth/sign-up",
+						"/api/v1/auth/sign-in/**",
+						"/api/v1/auth/reissue"
+					).permitAll()
 					.anyRequest().authenticated()
 			)
 			.formLogin(Customizer.withDefaults())

--- a/packy-api/src/main/java/com/dilly/jwt/TokenProvider.java
+++ b/packy-api/src/main/java/com/dilly/jwt/TokenProvider.java
@@ -98,7 +98,7 @@ public class TokenProvider {
 		} catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
 			log.error(ErrorCode.MALFORMED_JWT.getMessage(), e);
 		} catch (ExpiredJwtException e) {
-			log.error(ErrorCode.EXPIRED_JWT.getMessage(), e);
+			log.warn(ErrorCode.EXPIRED_JWT.getMessage(), e);
 		} catch (UnsupportedJwtException e) {
 			log.error(ErrorCode.UNSUPPORTED_JWT.getMessage(), e);
 		} catch (IllegalArgumentException e) {

--- a/packy-api/src/main/java/com/dilly/jwt/TokenProvider.java
+++ b/packy-api/src/main/java/com/dilly/jwt/TokenProvider.java
@@ -1,24 +1,9 @@
 package com.dilly.jwt;
 
-import java.security.Key;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.stereotype.Component;
-
 import com.dilly.exception.AuthorizationFailedException;
 import com.dilly.exception.ErrorCode;
 import com.dilly.jwt.dto.JwtResponse;
 import com.dilly.member.Member;
-
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -27,7 +12,19 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
@@ -94,19 +91,18 @@ public class TokenProvider {
 		return new UsernamePasswordAuthenticationToken(principal, "", authorities);
 	}
 
-	// TODO: 주석 해제하면 예외 처리 Response가 안 가고 500 에러가 남
 	public boolean validateToken(String token) {
 		try {
 			Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
 			return true;
 		} catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-			//            throw new AuthorizationFailedException(ErrorCode.MALFORMED_JWT);
+			log.error(ErrorCode.MALFORMED_JWT.getMessage(), e);
 		} catch (ExpiredJwtException e) {
-			//            throw new AuthorizationFailedException(ErrorCode.EXPIRED_JWT);
+			log.error(ErrorCode.EXPIRED_JWT.getMessage(), e);
 		} catch (UnsupportedJwtException e) {
-			//            throw new AuthorizationFailedException(ErrorCode.UNSUPPORTED_JWT);
+			log.error(ErrorCode.UNSUPPORTED_JWT.getMessage(), e);
 		} catch (IllegalArgumentException e) {
-			//            throw new AuthorizationFailedException(ErrorCode.ILLEGAL_JWT);
+			log.error(ErrorCode.ILLEGAL_JWT.getMessage(), e);
 		}
 		return false;
 	}

--- a/packy-domain/src/main/java/com/dilly/member/Provider.java
+++ b/packy-domain/src/main/java/com/dilly/member/Provider.java
@@ -3,5 +3,6 @@ package com.dilly.member;
 public enum Provider {
 
 	KAKAO,
-	APPLE;
+	APPLE,
+	TEST;
 }


### PR DESCRIPTION
## 🛰️ Issue Number
#69 

## 🪐 작업 내용
- SecurityConfig에 white list를 명시하여 허용된 엔드포인트만 JWT 없이 접근 가능하도록 하였습니다.
- 테스트용 회원가입 기능을 추가하였습니다.
- 토큰 검증 로직의 try-catch 절에 있던 주석을 지우고 에러 로그 출력 코드를 추가하였습니다.
  - ExpiredJwtException은 자주 뜰 것을 고려하여 로그 레벨을 WARN으로 설정했습니다.

## 📚 Reference

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [ ] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
