### PR TITLE
deploy: timezone 설정 명령어에 sudo 추가

### DIFF
--- a/.ebextensions/00-set-timezone.config
+++ b/.ebextensions/00-set-timezone.config
@@ -1,3 +1,3 @@
 commands:
   set_time_zone:
-    command: ln -f -s /usr/share/zoneinfo/Asia/Seoul /etc/localtime
+    command: sudo ln -f -s /usr/share/zoneinfo/Asia/Seoul /etc/localtime


### PR DESCRIPTION
## 🛰️ Issue Number
#73 

## 🪐 작업 내용
`.ebextensions/00-set-timezone.config` 에서 timezone을 변경하는 명령어 앞에 sudo를 추가했습니다.

## 📚 Reference

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
