### PR TITLE
fix: Server Driven UI 관련 API에 sequence 기준 정렬 조건 추가

### DIFF
--- a/packy-api/build.gradle
+++ b/packy-api/build.gradle
@@ -63,13 +63,6 @@ tasks.register('copySecret', Copy) {
     into './src/main/resources'
 }
 
-processTestResources.dependsOn('copySql')
-tasks.register('copySql', Copy) {
-    from '../packy-submodule/api'
-    include '*.sql'
-    into './src/test/resources'
-}
-
 if (project.hasProperty('dev')) {
     apply from: project.file('profile-dev.gradle');
 } else if (project.hasProperty('prod')) {

--- a/packy-api/src/main/java/com/dilly/admin/dto/response/MusicResponse.java
+++ b/packy-api/src/main/java/com/dilly/admin/dto/response/MusicResponse.java
@@ -1,8 +1,7 @@
 package com.dilly.admin.dto.response;
 
-import java.util.List;
-
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import lombok.Builder;
 
 @Builder
@@ -11,6 +10,8 @@ public record MusicResponse(
 	Long id,
 	@Schema(example = "www.youtube.com")
 	String youtubeUrl,
+	@Schema(example = "1")
+	Long sequence,
 	List<String> hashtags
 ) {
 }

--- a/packy-api/src/main/java/com/dilly/gift/domain/BoxReader.java
+++ b/packy-api/src/main/java/com/dilly/gift/domain/BoxReader.java
@@ -1,16 +1,13 @@
 package com.dilly.gift.domain;
 
-import java.util.List;
-
-import org.springframework.stereotype.Component;
-
 import com.dilly.admin.dto.response.BoxImgResponse;
 import com.dilly.exception.ErrorCode;
 import com.dilly.exception.entitynotfound.EntityNotFoundException;
 import com.dilly.gift.Box;
 import com.dilly.gift.dao.BoxRepository;
-
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
@@ -19,7 +16,7 @@ public class BoxReader {
 	private final BoxRepository boxRepository;
 
 	public List<BoxImgResponse> findAll() {
-		return boxRepository.findAll().stream()
+        return boxRepository.findAllByOrderBySequenceAsc().stream()
 			.map(box -> BoxImgResponse.builder()
 				.id(box.getId())
 				.boxFull(box.getFullImgUrl())

--- a/packy-api/src/main/java/com/dilly/gift/domain/EnvelopeReader.java
+++ b/packy-api/src/main/java/com/dilly/gift/domain/EnvelopeReader.java
@@ -1,16 +1,13 @@
 package com.dilly.gift.domain;
 
-import java.util.List;
-
-import org.springframework.stereotype.Component;
-
 import com.dilly.admin.dto.response.ImgResponse;
 import com.dilly.exception.ErrorCode;
 import com.dilly.exception.entitynotfound.EntityNotFoundException;
 import com.dilly.gift.Envelope;
 import com.dilly.gift.dao.EnvelopeRepository;
-
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
@@ -19,7 +16,7 @@ public class EnvelopeReader {
 	private final EnvelopeRepository envelopeRepository;
 
 	public List<ImgResponse> findAll() {
-		return envelopeRepository.findAll().stream()
+		return envelopeRepository.findAllByOrderBySequenceAsc().stream()
 			.map(envelope -> ImgResponse.builder()
 				.id(envelope.getId())
 				.imgUrl(envelope.getImgUrl())

--- a/packy-api/src/main/java/com/dilly/gift/domain/MusicReader.java
+++ b/packy-api/src/main/java/com/dilly/gift/domain/MusicReader.java
@@ -1,15 +1,12 @@
 package com.dilly.gift.domain;
 
-import java.util.List;
-
-import org.springframework.stereotype.Component;
-
 import com.dilly.admin.dto.response.MusicResponse;
 import com.dilly.gift.Music;
 import com.dilly.gift.MusicHashtag;
 import com.dilly.gift.dao.MusicRepository;
-
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
@@ -18,9 +15,10 @@ public class MusicReader {
 	private final MusicRepository musicRepository;
 
 	public List<MusicResponse> findAll() {
-		return musicRepository.findAll().stream()
+        return musicRepository.findAllByOrderBySequenceAsc().stream()
 			.map(music -> MusicResponse.builder()
 				.id(music.getId())
+                .sequence(music.getSequence())
 				.youtubeUrl(music.getYoutubeUrl())
 				.hashtags(getHashTags(music))
 				.build()

--- a/packy-api/src/main/java/com/dilly/member/domain/ProfileImageReader.java
+++ b/packy-api/src/main/java/com/dilly/member/domain/ProfileImageReader.java
@@ -1,14 +1,11 @@
 package com.dilly.member.domain;
 
-import java.util.List;
-
-import org.springframework.stereotype.Component;
-
 import com.dilly.admin.dto.response.ImgResponse;
 import com.dilly.gift.dao.ProfileImageRepository;
 import com.dilly.member.ProfileImage;
-
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
@@ -22,7 +19,7 @@ public class ProfileImageReader {
 	}
 
 	public List<ImgResponse> findAll() {
-		return profileImageRepository.findAll().stream()
+        return profileImageRepository.findAllByOrderBySequenceAsc().stream()
 			.map(profileImage -> ImgResponse.builder()
 				.id(profileImage.getId())
 				.imgUrl(profileImage.getImgUrl())

--- a/packy-api/src/test/java/com/dilly/admin/api/AdminControllerTest.java
+++ b/packy-api/src/test/java/com/dilly/admin/api/AdminControllerTest.java
@@ -1,21 +1,20 @@
 package com.dilly.admin.api;
 
-import static org.hamcrest.Matchers.*;
-import static org.mockito.BDDMockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import java.util.List;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.dilly.admin.dto.response.BoxImgResponse;
 import com.dilly.admin.dto.response.ImgResponse;
 import com.dilly.admin.dto.response.MusicResponse;
 import com.dilly.global.ControllerTestSupport;
 import com.dilly.global.WithCustomMockUser;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 class AdminControllerTest extends ControllerTestSupport {
 
@@ -125,8 +124,10 @@ class AdminControllerTest extends ControllerTestSupport {
 		// given
 		List<String> hashtags = List.of("#테스트1", "#테스트2");
 		List<MusicResponse> musics = List.of(
-			MusicResponse.builder().id(1L).youtubeUrl("www.youtube.com").hashtags(hashtags).build(),
-			MusicResponse.builder().id(2L).youtubeUrl("www.youtube.com").hashtags(hashtags).build());
+			MusicResponse.builder().id(1L).sequence(1L).youtubeUrl("www.youtube.com")
+				.hashtags(hashtags).build(),
+			MusicResponse.builder().id(2L).sequence(2L).youtubeUrl("www.youtube.com")
+				.hashtags(hashtags).build());
 
 		given(adminService.getMusics()).willReturn(musics);
 

--- a/packy-api/src/test/java/com/dilly/admin/application/AdminServiceTest.java
+++ b/packy-api/src/test/java/com/dilly/admin/application/AdminServiceTest.java
@@ -80,6 +80,7 @@ class AdminServiceTest extends IntegrationTestSupport {
         List<MusicResponse> musics = musicRepository.findAll()
             .stream().map(music -> MusicResponse.builder()
                 .id(music.getId())
+                .sequence(music.getSequence())
                 .youtubeUrl(music.getYoutubeUrl())
                 .hashtags(music.getHashtags().stream().map(MusicHashtag::getHashtag).toList())
                 .build()

--- a/packy-api/src/test/java/com/dilly/global/IntegrationTestSupport.java
+++ b/packy-api/src/test/java/com/dilly/global/IntegrationTestSupport.java
@@ -21,7 +21,7 @@ import org.springframework.test.context.TestPropertySource;
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = "spring.profiles.active=test"
 )
-@TestPropertySource(locations = {"classpath:application-test.yml", "classpath:data.sql"})
+@TestPropertySource(locations = {"classpath:application-test.yml"})
 @Transactional
 public abstract class IntegrationTestSupport {
 

--- a/packy-domain/src/main/java/com/dilly/gift/Music.java
+++ b/packy-domain/src/main/java/com/dilly/gift/Music.java
@@ -1,13 +1,12 @@
 package com.dilly.gift;
 
-import static jakarta.persistence.GenerationType.*;
-
-import java.util.List;
+import static jakarta.persistence.GenerationType.IDENTITY;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import java.util.List;
 import lombok.Getter;
 
 @Entity
@@ -19,6 +18,8 @@ public class Music {
 	private Long id;
 
 	private String youtubeUrl;
+
+    private Long sequence;
 
 	@OneToMany(mappedBy = "music")
 	private List<MusicHashtag> hashtags;

--- a/packy-domain/src/main/java/com/dilly/gift/dao/BoxRepository.java
+++ b/packy-domain/src/main/java/com/dilly/gift/dao/BoxRepository.java
@@ -1,8 +1,10 @@
 package com.dilly.gift.dao;
 
+import com.dilly.gift.Box;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.dilly.gift.Box;
-
 public interface BoxRepository extends JpaRepository<Box, Long> {
+
+    List<Box> findAllByOrderBySequenceAsc();
 }

--- a/packy-domain/src/main/java/com/dilly/gift/dao/EnvelopeRepository.java
+++ b/packy-domain/src/main/java/com/dilly/gift/dao/EnvelopeRepository.java
@@ -1,8 +1,10 @@
 package com.dilly.gift.dao;
 
+import com.dilly.gift.Envelope;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.dilly.gift.Envelope;
-
 public interface EnvelopeRepository extends JpaRepository<Envelope, Long> {
+
+    List<Envelope> findAllByOrderBySequenceAsc();
 }

--- a/packy-domain/src/main/java/com/dilly/gift/dao/MusicRepository.java
+++ b/packy-domain/src/main/java/com/dilly/gift/dao/MusicRepository.java
@@ -1,8 +1,10 @@
 package com.dilly.gift.dao;
 
+import com.dilly.gift.Music;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.dilly.gift.Music;
-
 public interface MusicRepository extends JpaRepository<Music, Long> {
+
+    List<Music> findAllByOrderBySequenceAsc();
 }

--- a/packy-domain/src/main/java/com/dilly/gift/dao/ProfileImageRepository.java
+++ b/packy-domain/src/main/java/com/dilly/gift/dao/ProfileImageRepository.java
@@ -1,8 +1,10 @@
 package com.dilly.gift.dao;
 
+import com.dilly.member.ProfileImage;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.dilly.member.ProfileImage;
-
 public interface ProfileImageRepository extends JpaRepository<ProfileImage, Long> {
+
+    List<ProfileImage> findAllByOrderBySequenceAsc();
 }

--- a/packy-domain/src/main/java/com/dilly/gift/dao/querydsl/StickerQueryRepository.java
+++ b/packy-domain/src/main/java/com/dilly/gift/dao/querydsl/StickerQueryRepository.java
@@ -21,8 +21,8 @@ public class StickerQueryRepository {
     public Slice<Sticker> searchBySlice(Long lastStickerId, Pageable pageable) {
         List<Sticker> results = jpaQueryFactory.selectFrom(sticker)
             .where(gtStickerId(lastStickerId))
-            .orderBy(sticker.id.asc())
-            .limit(pageable.getPageSize() + 1)
+            .orderBy(sticker.sequence.asc())
+            .limit(pageable.getPageSize() + 1L)
             .fetch();
 
         return checkLastPage(pageable, results);

--- a/packy-domain/src/main/resources/db/migration/V15__add_sequence_in_music_table.sql
+++ b/packy-domain/src/main/resources/db/migration/V15__add_sequence_in_music_table.sql
@@ -1,0 +1,2 @@
+alter table music
+add column sequence bigint;

--- a/packy-domain/src/main/resources/db/migration/V16__add_provider_enum_in_member_table.sql
+++ b/packy-domain/src/main/resources/db/migration/V16__add_provider_enum_in_member_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE member
+MODIFY COLUMN provider ENUM('KAKAO', 'APPLE', 'TEST');


### PR DESCRIPTION
## 🛰️ Issue Number
#68 

## 🪐 작업 내용
1. Server Driven UI 관련 API에 sequence 기준 정렬 조건을 추가하였습니다.
2. 테스트 코드에서의 data.sql 중복 삽입 문제를 해결하였습니다.

### data.sql 중복 삽입 문제 트러블 슈팅
- 문제 상황: 테스트 코드를 수정하던 도중 Server Driven UI 더미데이터 삽입을 위해 작성했던 data.sql이 2번 실행된 것을 확인하였습니다.
- 원인 파악: [블로그 포스트](https://ksh-coding.tistory.com/99)를 참고하여 `@SpringBootTest의 RANDOM_PORT로 실행하면
src/test/resources 디렉토리가 아닌 src/main/resources의 data.sql을 읽게 된다`는 문구를 통해 main 패키지의 data.sql과 test 패키지의 data.sql을 둘 다 읽어서 발생한 문제라고 추측하였습니다. (왜 main 패키지만 읽지 않고 test 패키지까지 읽어들이는지는 아직도 모르겠습니다 ㅠㅠ)
- 문제 해결 과정 1: @Sql과 @BeforeEach, @BeforeAll 등을 사용하여 테스트 실행 전에 sql 스크립트를 실행하고, 테스트가 끝난 이후 사용했던 데이터와 테이블을 지우는 방법이 있습니다. 하지만 2초 가량이였던 테스트 실행 시간이 6초 가량으로 증가하기 때문에 효율적이지 않은 방법이라고 생각했습니다.
- 문제 해결 과정 2: 로컬용 data.sql과 테스트용 data.sql의 차이는 테스트 유저 삽입 유무로, 큰 영향을 미치는 요소가 아니기 때문에 로컬용 data.sql에 해당 쿼리를 추가하고 로컬과 테스트 환경에서 data.sql을 함께 사용하도록 했습니다.

### 부가 작업
> org.springframework.orm.jpa.JpaSystemException: could not execute statement [Data truncated for column 'provider' at row 1] [insert into member (created_at,marketing_agreement,nickname,profile_img_id,provider,push_notification,role,status,updated_at) values (?,?,?,?,?,?,?,?,?)]

개발용 DB의 member 테이블의 provider 컬럼 enum 값에 TEST가 없어 테스트 유저 회원가입 시 위와 같은 에러를 반환하며 동작하지 않았습니다. 개발 서버에서도 테스트 회원가입이 가능하도록 flyway 스크립트를 통해 컬럼 정보를 수정해주었습니다.

## 📚 Reference
- https://ksh-coding.tistory.com/99

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
