### PR TITLE
fix: 선물박스 엔티티에 선물박스 이름 추가

### DIFF
--- a/packy-api/src/main/java/com/dilly/gift/application/GiftService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftService.java
@@ -48,7 +48,8 @@ public class GiftService {
             .giftUrl(giftBoxRequest.gift().url())
             .build();
 
-        GiftBox giftBox = giftBoxWriter.save(box, letter, giftBoxRequest.youtubeUrl(), gift);
+        GiftBox giftBox = giftBoxWriter.save(box, letter, gift, giftBoxRequest.name(),
+            giftBoxRequest.youtubeUrl());
 
         for (PhotoRequest photoRequest : giftBoxRequest.photos()) {
             photoWriter.save(giftBox, photoRequest);

--- a/packy-api/src/main/java/com/dilly/gift/domain/GiftBoxWriter.java
+++ b/packy-api/src/main/java/com/dilly/gift/domain/GiftBoxWriter.java
@@ -1,16 +1,13 @@
 package com.dilly.gift.domain;
 
-import java.util.UUID;
-
-import org.springframework.stereotype.Component;
-
 import com.dilly.gift.Box;
 import com.dilly.gift.Gift;
 import com.dilly.gift.GiftBox;
 import com.dilly.gift.Letter;
 import com.dilly.gift.dao.GiftBoxRepository;
-
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
@@ -18,9 +15,11 @@ public class GiftBoxWriter {
 
 	private final GiftBoxRepository giftBoxRepository;
 
-	public GiftBox save(Box box, Letter letter, String youtubeUrl, Gift gift) {
+	public GiftBox save(Box box, Letter letter, Gift gift,
+		String name, String youtubeUrl) {
 		return giftBoxRepository.save(GiftBox.builder()
 			.uuid(UUID.randomUUID().toString())
+			.name(name)
 			.box(box)
 			.letter(letter)
 			.youtubeUrl(youtubeUrl)

--- a/packy-api/src/test/java/com/dilly/gift/application/GiftServiceTest.java
+++ b/packy-api/src/test/java/com/dilly/gift/application/GiftServiceTest.java
@@ -65,6 +65,7 @@ class GiftServiceTest extends IntegrationTestSupport {
 
         // then
         assertThat(giftBox.getBox().getId()).isEqualTo(giftBoxRequest.boxId());
+        assertThat(giftBox.getName()).isEqualTo(giftBoxRequest.name());
         assertThat(giftBox.getLetter().getEnvelope().getId()).isEqualTo(
             giftBoxRequest.envelopeId());
         assertThat(giftBox.getLetter().getContent()).isEqualTo(giftBoxRequest.letterContent());

--- a/packy-domain/src/main/java/com/dilly/gift/GiftBox.java
+++ b/packy-domain/src/main/java/com/dilly/gift/GiftBox.java
@@ -27,6 +27,8 @@ public class GiftBox extends BaseTimeEntity {
 
     private String uuid;
 
+    private String name;
+
     @ManyToOne(fetch = FetchType.LAZY)
     private Box box;
 

--- a/packy-domain/src/main/resources/db/migration/V17__add_name_in_gift_box_table.sql
+++ b/packy-domain/src/main/resources/db/migration/V17__add_name_in_gift_box_table.sql
@@ -1,0 +1,2 @@
+alter table gift_box
+add column name varchar(255);


### PR DESCRIPTION
## 🛰️ Issue Number
#84 

## 🪐 작업 내용
선물박스 엔티티에 선물박스 이름(name) 컬럼을 추가하고, 선물박스 만들기 API에서 엔티티 저장 시 이름도 저장하도록 수정하였습니다.

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [ ] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
