### PR TITLE
fix: 패키 추천 음악 조회 API에 제목 추가

### DIFF
--- a/packy-api/src/main/java/com/dilly/admin/dto/response/MusicResponse.java
+++ b/packy-api/src/main/java/com/dilly/admin/dto/response/MusicResponse.java
@@ -10,6 +10,8 @@ public record MusicResponse(
 	Long id,
 	@Schema(example = "www.youtube.com")
 	String youtubeUrl,
+	@Schema(example = "행복한 날에 어울리는 행복한 음악")
+	String title,
 	@Schema(example = "1")
 	Long sequence,
 	List<String> hashtags

--- a/packy-api/src/main/java/com/dilly/gift/domain/MusicReader.java
+++ b/packy-api/src/main/java/com/dilly/gift/domain/MusicReader.java
@@ -19,6 +19,7 @@ public class MusicReader {
 			.map(music -> MusicResponse.builder()
 				.id(music.getId())
                 .sequence(music.getSequence())
+				.title(music.getTitle())
 				.youtubeUrl(music.getYoutubeUrl())
 				.hashtags(getHashTags(music))
 				.build()

--- a/packy-api/src/test/java/com/dilly/admin/api/AdminControllerTest.java
+++ b/packy-api/src/test/java/com/dilly/admin/api/AdminControllerTest.java
@@ -124,9 +124,9 @@ class AdminControllerTest extends ControllerTestSupport {
 		// given
 		List<String> hashtags = List.of("#테스트1", "#테스트2");
 		List<MusicResponse> musics = List.of(
-			MusicResponse.builder().id(1L).sequence(1L).youtubeUrl("www.youtube.com")
+			MusicResponse.builder().id(1L).sequence(1L).title("test1").youtubeUrl("www.youtube.com")
 				.hashtags(hashtags).build(),
-			MusicResponse.builder().id(2L).sequence(2L).youtubeUrl("www.youtube.com")
+			MusicResponse.builder().id(2L).sequence(2L).title("test2").youtubeUrl("www.youtube.com")
 				.hashtags(hashtags).build());
 
 		given(adminService.getMusics()).willReturn(musics);

--- a/packy-api/src/test/java/com/dilly/admin/application/AdminServiceTest.java
+++ b/packy-api/src/test/java/com/dilly/admin/application/AdminServiceTest.java
@@ -81,6 +81,7 @@ class AdminServiceTest extends IntegrationTestSupport {
             .stream().map(music -> MusicResponse.builder()
                 .id(music.getId())
                 .sequence(music.getSequence())
+                .title(music.getTitle())
                 .youtubeUrl(music.getYoutubeUrl())
                 .hashtags(music.getHashtags().stream().map(MusicHashtag::getHashtag).toList())
                 .build()

--- a/packy-domain/src/main/java/com/dilly/gift/Music.java
+++ b/packy-domain/src/main/java/com/dilly/gift/Music.java
@@ -19,6 +19,8 @@ public class Music {
 
 	private String youtubeUrl;
 
+	private String title;
+
     private Long sequence;
 
 	@OneToMany(mappedBy = "music")

--- a/packy-domain/src/main/resources/db/migration/V18__add_title_in_music_table.sql
+++ b/packy-domain/src/main/resources/db/migration/V18__add_title_in_music_table.sql
@@ -1,0 +1,2 @@
+alter table music
+add column title varchar(255);


### PR DESCRIPTION
## 🛰️ Issue Number
#83 

## 🪐 작업 내용
클라이언트의 요청에 따라 패키 추천 음악 조회 API에 제목(title)을 추가하였습니다.

## 📚 Reference

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [ ] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
