### PR TITLE
fix: 선물박스 만들기 API에서 선물이 없을 경우 Gift를 null로 저장

### DIFF
--- a/packy-api/src/main/java/com/dilly/gift/application/GiftService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftService.java
@@ -45,13 +45,20 @@ public class GiftService {
         Box box = boxReader.findById(giftBoxRequest.boxId());
         Envelope envelope = envelopeReader.findById(giftBoxRequest.envelopeId());
         Letter letter = letterWriter.save(giftBoxRequest.letterContent(), envelope);
-        Gift gift = Gift.builder()
-            .giftType(GiftType.valueOf(giftBoxRequest.gift().type().toUpperCase()))
-            .giftUrl(giftBoxRequest.gift().url())
-            .build();
 
-        GiftBox giftBox = giftBoxWriter.save(box, letter, gift, sender,
-            giftBoxRequest.name(), giftBoxRequest.youtubeUrl());
+        GiftBox giftBox;
+        if (giftBoxRequest.gift() == null) {
+            giftBox = giftBoxWriter.save(box, letter, sender,
+                giftBoxRequest.name(), giftBoxRequest.youtubeUrl());
+        } else {
+            Gift gift = Gift.builder()
+                .giftType(GiftType.valueOf(giftBoxRequest.gift().type().toUpperCase()))
+                .giftUrl(giftBoxRequest.gift().url())
+                .build();
+
+            giftBox = giftBoxWriter.save(box, letter, gift, sender,
+                giftBoxRequest.name(), giftBoxRequest.youtubeUrl());
+        }
 
         for (PhotoRequest photoRequest : giftBoxRequest.photos()) {
             photoWriter.save(giftBox, photoRequest);

--- a/packy-api/src/main/java/com/dilly/gift/domain/GiftBoxWriter.java
+++ b/packy-api/src/main/java/com/dilly/gift/domain/GiftBoxWriter.java
@@ -28,4 +28,16 @@ public class GiftBoxWriter {
 			.gift(gift)
 			.build());
 	}
+
+	public GiftBox save(Box box, Letter letter, Member member,
+		String name, String youtubeUrl) {
+		return giftBoxRepository.save(GiftBox.builder()
+			.uuid(UUID.randomUUID().toString())
+			.name(name)
+			.sender(member)
+			.box(box)
+			.letter(letter)
+			.youtubeUrl(youtubeUrl)
+			.build());
+	}
 }

--- a/packy-api/src/test/java/com/dilly/gift/api/GiftControllerTest.java
+++ b/packy-api/src/test/java/com/dilly/gift/api/GiftControllerTest.java
@@ -14,58 +14,99 @@ import com.dilly.gift.dto.request.StickerRequest;
 import com.dilly.gift.dto.response.GiftBoxResponse;
 import com.dilly.global.ControllerTestSupport;
 import com.dilly.global.WithCustomMockUser;
+import java.util.Collection;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
 import org.springframework.http.MediaType;
 
 class GiftControllerTest extends ControllerTestSupport {
 
-    @DisplayName("선물박스를 만든다.")
-    @Test
+    @DisplayName("선물박스 만들기 시나리오")
+    @TestFactory
     @WithCustomMockUser
-    void createGiftBox() throws Exception {
+    Collection<DynamicTest> createGiftBox() {
         // given
-        GiftBoxRequest giftBoxRequest = GiftBoxRequest.builder()
-            .name("test")
-            .senderName("sender")
-            .receiverName("receiver")
-            .boxId(1L)
-            .envelopeId(1L)
-            .letterContent("This is letter content.")
-            .youtubeUrl("www.youtube.com")
-            .photos(List.of(
-                PhotoRequest.builder().photoUrl("www.test1.com").description("description1")
-                    .build(),
-                PhotoRequest.builder().photoUrl("www.test2.com").description("description2").build()
-            ))
-            .stickers(List.of(
-                StickerRequest.builder().id(1L).location(1).build(),
-                StickerRequest.builder().id(2L).location(2).build())
-            )
-            .gift(GiftRequest.builder()
-                .type("photo")
-                .url("www.naver.com")
+        List<PhotoRequest> photos = List.of(
+            PhotoRequest.builder()
+                .photoUrl("www.test1.com").description("description1").sequence(1)
+                .build(),
+            PhotoRequest.builder()
+                .photoUrl("www.test2.com").description("description2").sequence(2)
                 .build()
-            )
-            .build();
+        );
+        List<StickerRequest> stickers = List.of(
+            StickerRequest.builder().id(1L).location(1).build(),
+            StickerRequest.builder().id(2L).location(2).build());
         GiftBoxResponse giftBoxResponse = GiftBoxResponse.builder()
             .id(1L)
             .uuid("550e8400-e29b-41d4-a716-446655440000")
             .build();
 
-        given(giftService.createGiftBox(giftBoxRequest)).willReturn(giftBoxResponse);
+        return List.of(
+            DynamicTest.dynamicTest("선물이 있을 경우", () -> {
+                //given
+                GiftBoxRequest giftBoxRequest = GiftBoxRequest.builder()
+                    .name("test")
+                    .senderName("sender")
+                    .receiverName("receiver")
+                    .boxId(1L)
+                    .envelopeId(1L)
+                    .letterContent("This is letter content.")
+                    .youtubeUrl("www.youtube.com")
+                    .photos(photos)
+                    .stickers(stickers)
+                    .gift(GiftRequest.builder()
+                        .type("photo")
+                        .url("www.naver.com")
+                        .build()
+                    )
+                    .build();
 
-        // when // then
-        mockMvc.perform(
-                post(baseUrl + "/giftbox")
-                    .with(csrf())
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(giftBoxRequest))
-            )
-            .andDo(print())
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.data.id").isNumber())
-            .andExpect(jsonPath("$.data.uuid").isString());
+                given(giftService.createGiftBox(giftBoxRequest)).willReturn(giftBoxResponse);
+
+                // when // then
+                mockMvc.perform(
+                        post(baseUrl + "/giftbox")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(giftBoxRequest))
+                    )
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.id").isNumber())
+                    .andExpect(jsonPath("$.data.uuid").isString());
+            }),
+            DynamicTest.dynamicTest("선물이 없을 경우", () -> {
+                //given
+                GiftBoxRequest giftBoxRequest = GiftBoxRequest.builder()
+                    .name("test")
+                    .senderName("sender")
+                    .receiverName("receiver")
+                    .boxId(1L)
+                    .envelopeId(1L)
+                    .letterContent("This is letter content.")
+                    .youtubeUrl("www.youtube.com")
+                    .photos(photos)
+                    .stickers(stickers)
+                    .gift(null)
+                    .build();
+
+                given(giftService.createGiftBox(giftBoxRequest)).willReturn(giftBoxResponse);
+
+                // when // then
+                mockMvc.perform(
+                        post(baseUrl + "/giftbox")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(giftBoxRequest))
+                    )
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.id").isNumber())
+                    .andExpect(jsonPath("$.data.uuid").isString());
+            })
+        );
     }
 }

--- a/packy-api/src/test/java/com/dilly/gift/application/GiftServiceTest.java
+++ b/packy-api/src/test/java/com/dilly/gift/application/GiftServiceTest.java
@@ -15,70 +15,120 @@ import com.dilly.global.IntegrationTestSupport;
 import com.dilly.global.WithCustomMockUser;
 import com.dilly.global.utils.SecurityUtil;
 import com.dilly.member.Member;
+import java.util.Collection;
 import java.util.List;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
 
 class GiftServiceTest extends IntegrationTestSupport {
 
-    @DisplayName("선물 박스를 만든다.")
-    @Test
+    @DisplayName("선물박스 만들기 시나리오")
+    @TestFactory
     @WithCustomMockUser
-    void createGiftBox() {
+    Collection<DynamicTest> createGiftBox() {
         // given
         Long memberId = SecurityUtil.getMemberId();
         Member member = memberRepository.findById(memberId).orElseThrow();
 
-        GiftBoxRequest giftBoxRequest = GiftBoxRequest.builder()
-            .name("test")
-            .senderName("sender")
-            .receiverName("receiver")
-            .boxId(1L)
-            .envelopeId(1L)
-            .letterContent("This is letter content.")
-            .youtubeUrl("www.youtube.com")
-            .photos(List.of(
-                PhotoRequest.builder().photoUrl("www.test1.com").description("description1")
-                    .sequence(1).build(),
-                PhotoRequest.builder().photoUrl("www.test2.com").description("description2")
-                    .sequence(2).build()
-            ))
-            .stickers(List.of(
-                StickerRequest.builder().id(1L).location(1).build(),
-                StickerRequest.builder().id(2L).location(2).build())
-            )
-            .gift(GiftRequest.builder()
-                .type("photo")
-                .url("www.naver.com")
+        List<PhotoRequest> photoRequests = List.of(
+            PhotoRequest.builder()
+                .photoUrl("www.test1.com").description("description1").sequence(1)
+                .build(),
+            PhotoRequest.builder()
+                .photoUrl("www.test2.com").description("description2").sequence(2)
                 .build()
-            )
-            .build();
+        );
+        List<StickerRequest> stickers = List.of(
+            StickerRequest.builder().id(1L).location(1).build(),
+            StickerRequest.builder().id(2L).location(2).build());
 
-        // when
-        GiftBoxResponse giftBoxResponse = giftService.createGiftBox(giftBoxRequest);
-        GiftBox giftBox = giftBoxRepository.findTopByOrderByIdDesc();
-        List<Photo> photos = photoRepository.findAllByGiftBox(giftBox);
+        return List.of(
+            DynamicTest.dynamicTest("선물이 있을 경우", () -> {
+                //given
+                GiftBoxRequest giftBoxRequest = GiftBoxRequest.builder()
+                    .name("test")
+                    .senderName("sender")
+                    .receiverName("receiver")
+                    .boxId(1L)
+                    .envelopeId(1L)
+                    .letterContent("This is letter content.")
+                    .youtubeUrl("www.youtube.com")
+                    .photos(photoRequests)
+                    .stickers(stickers)
+                    .gift(GiftRequest.builder()
+                        .type("photo")
+                        .url("www.naver.com")
+                        .build()
+                    )
+                    .build();
 
-        // then
-        assertThat(giftBox.getBox().getId()).isEqualTo(giftBoxRequest.boxId());
-        assertThat(giftBox.getName()).isEqualTo(giftBoxRequest.name());
-        assertThat(giftBox.getLetter().getEnvelope().getId()).isEqualTo(
-            giftBoxRequest.envelopeId());
-        assertThat(giftBox.getLetter().getContent()).isEqualTo(giftBoxRequest.letterContent());
-        assertThat(giftBox.getYoutubeUrl()).isEqualTo(giftBoxRequest.youtubeUrl());
-        assertThat(giftBox.getGift().getGiftType().name()).isEqualTo(
-            giftBoxRequest.gift().type().toUpperCase());
-        assertThat(giftBox.getGift().getGiftUrl()).isEqualTo(giftBoxRequest.gift().url());
-        assertThat(photos).hasSize(2)
-            .extracting("imgUrl", "description", "sequence")
-            .contains(tuple("www.test1.com", "description1", 1),
-                tuple("www.test2.com", "description2", 2));
-        assertThat(giftBoxResponse.id()).isEqualTo(giftBox.getId());
-        assertTrue(isValidUUID(giftBoxResponse.uuid()));
+                // when
+                GiftBoxResponse giftBoxResponse = giftService.createGiftBox(giftBoxRequest);
+                GiftBox giftBox = giftBoxRepository.findTopByOrderByIdDesc();
+                List<Photo> photos = photoRepository.findAllByGiftBox(giftBox);
+
+                // then
+                assertThat(giftBox.getBox().getId()).isEqualTo(giftBoxRequest.boxId());
+                assertThat(giftBox.getName()).isEqualTo(giftBoxRequest.name());
+                assertThat(giftBox.getLetter().getEnvelope().getId()).isEqualTo(
+                    giftBoxRequest.envelopeId());
+                assertThat(giftBox.getLetter().getContent()).isEqualTo(
+                    giftBoxRequest.letterContent());
+                assertThat(giftBox.getYoutubeUrl()).isEqualTo(giftBoxRequest.youtubeUrl());
+                assertThat(giftBox.getGift().getGiftType().name()).isEqualTo(
+                    giftBoxRequest.gift().type().toUpperCase());
+                assertThat(giftBox.getGift().getGiftUrl()).isEqualTo(giftBoxRequest.gift().url());
+                assertThat(photos).hasSize(2)
+                    .extracting("imgUrl", "description", "sequence")
+                    .contains(tuple("www.test1.com", "description1", 1),
+                        tuple("www.test2.com", "description2", 2));
+
+                assertThat(giftBoxResponse.id()).isEqualTo(giftBox.getId());
+                assertTrue(isValidUUID(giftBoxResponse.uuid()));
+            }),
+            DynamicTest.dynamicTest("선물이 없을 경우", () -> {
+                //given
+                GiftBoxRequest giftBoxRequest = GiftBoxRequest.builder()
+                    .name("test")
+                    .senderName("sender")
+                    .receiverName("receiver")
+                    .boxId(1L)
+                    .envelopeId(1L)
+                    .letterContent("This is letter content.")
+                    .youtubeUrl("www.youtube.com")
+                    .photos(photoRequests)
+                    .stickers(stickers)
+                    .build();
+
+                // when
+                GiftBoxResponse giftBoxResponse = giftService.createGiftBox(giftBoxRequest);
+                GiftBox giftBox = giftBoxRepository.findTopByOrderByIdDesc();
+                List<Photo> photos = photoRepository.findAllByGiftBox(giftBox);
+
+                // then
+                assertThat(giftBox.getBox().getId()).isEqualTo(giftBoxRequest.boxId());
+                assertThat(giftBox.getName()).isEqualTo(giftBoxRequest.name());
+                assertThat(giftBox.getLetter().getEnvelope().getId()).isEqualTo(
+                    giftBoxRequest.envelopeId());
+                assertThat(giftBox.getLetter().getContent()).isEqualTo(
+                    giftBoxRequest.letterContent());
+                assertThat(giftBox.getYoutubeUrl()).isEqualTo(giftBoxRequest.youtubeUrl());
+                assertThat(giftBox.getGift()).isNull();
+                assertThat(photos).hasSize(2)
+                    .extracting("imgUrl", "description", "sequence")
+                    .contains(tuple("www.test1.com", "description1", 1),
+                        tuple("www.test2.com", "description2", 2));
+
+                assertThat(giftBoxResponse.id()).isEqualTo(giftBox.getId());
+                assertTrue(isValidUUID(giftBoxResponse.uuid()));
+            })
+        );
     }
 
-    public static boolean isValidUUID(String value) {
+
+    private boolean isValidUUID(String value) {
         final Pattern uuidPattern =
             Pattern.compile(
                 "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");


### PR DESCRIPTION
## 🛰️ Issue Number
#78 

## 🪐 작업 내용
선물박스 만들기 API에서 선물이 없을 경우를 고려하지 않아 Gift 객체를 만드는 코드에서 에러가 발생하고 있습니다. 
gift 컬럼이 null로 들어오면 Gift를 null로 하여 GiftBox 엔티티를 저장하도록 수정하였습니다.

## 📚 Reference

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
