### PR TITLE
fix: 선물박스 엔티티와 편지 봉투 엔티티 수정

### DIFF
--- a/packy-api/src/main/java/com/dilly/admin/api/AdminController.java
+++ b/packy-api/src/main/java/com/dilly/admin/api/AdminController.java
@@ -6,6 +6,7 @@ import com.dilly.admin.dto.response.ImgResponse;
 import com.dilly.admin.dto.response.MusicResponse;
 import com.dilly.application.YoutubeService;
 import com.dilly.dto.response.StatusResponse;
+import com.dilly.gift.dto.response.EnvelopeListResponse;
 import com.dilly.global.response.DataResponseDto;
 import com.dilly.global.response.SliceResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -53,7 +54,7 @@ public class AdminController {
 
     @Operation(summary = "편지 봉투 디자인 조회")
     @GetMapping("/design/envelopes")
-    public DataResponseDto<List<ImgResponse>> getEnvelopes() {
+    public DataResponseDto<List<EnvelopeListResponse>> getEnvelopes() {
         return DataResponseDto.from(adminService.getEnvelopes());
     }
 

--- a/packy-api/src/main/java/com/dilly/admin/application/AdminService.java
+++ b/packy-api/src/main/java/com/dilly/admin/application/AdminService.java
@@ -7,6 +7,7 @@ import com.dilly.gift.domain.BoxReader;
 import com.dilly.gift.domain.EnvelopeReader;
 import com.dilly.gift.domain.MusicReader;
 import com.dilly.gift.domain.StickerReader;
+import com.dilly.gift.dto.response.EnvelopeListResponse;
 import com.dilly.member.domain.ProfileImageReader;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -36,7 +37,7 @@ public class AdminService {
         return boxReader.findAll();
     }
 
-    public List<ImgResponse> getEnvelopes() {
+    public List<EnvelopeListResponse> getEnvelopes() {
         return envelopeReader.findAll();
     }
 

--- a/packy-api/src/main/java/com/dilly/gift/api/GiftController.java
+++ b/packy-api/src/main/java/com/dilly/gift/api/GiftController.java
@@ -2,6 +2,7 @@ package com.dilly.gift.api;
 
 import com.dilly.gift.application.GiftService;
 import com.dilly.gift.dto.request.GiftBoxRequest;
+import com.dilly.gift.dto.response.GiftBoxIdResponse;
 import com.dilly.gift.dto.response.GiftBoxResponse;
 import com.dilly.global.response.DataResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,7 +23,7 @@ public class GiftController {
 
     @Operation(summary = "선물박스 만들기", description = "giftType은 photo만 가능합니다.")
     @PostMapping("")
-    public DataResponseDto<GiftBoxResponse> createGiftBox(
+    public DataResponseDto<GiftBoxIdResponse> createGiftBox(
         @RequestBody GiftBoxRequest giftBoxRequest
     ) {
         return DataResponseDto.from(giftService.createGiftBox(giftBoxRequest));

--- a/packy-api/src/main/java/com/dilly/gift/application/GiftService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftService.java
@@ -15,6 +15,7 @@ import com.dilly.gift.domain.PhotoWriter;
 import com.dilly.gift.dto.request.GiftBoxRequest;
 import com.dilly.gift.dto.request.PhotoRequest;
 import com.dilly.gift.dto.request.StickerRequest;
+import com.dilly.gift.dto.response.GiftBoxIdResponse;
 import com.dilly.gift.dto.response.GiftBoxResponse;
 import com.dilly.global.utils.SecurityUtil;
 import com.dilly.member.Member;
@@ -38,7 +39,7 @@ public class GiftService {
     private final GiftBoxStickerWriter giftBoxStickerWriter;
     private final MemberReader memberReader;
 
-    public GiftBoxResponse createGiftBox(GiftBoxRequest giftBoxRequest) {
+    public GiftBoxIdResponse createGiftBox(GiftBoxRequest giftBoxRequest) {
         Long memberId = SecurityUtil.getMemberId();
         Member sender = memberReader.findById(memberId);
 
@@ -68,7 +69,7 @@ public class GiftService {
             giftBoxStickerWriter.save(giftBox, stickerRequest);
         }
 
-        return GiftBoxResponse.builder()
+        return GiftBoxIdResponse.builder()
             .id(giftBox.getId())
             .uuid(giftBox.getUuid())
             .build();

--- a/packy-api/src/main/java/com/dilly/gift/application/GiftService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftService.java
@@ -16,7 +16,6 @@ import com.dilly.gift.dto.request.GiftBoxRequest;
 import com.dilly.gift.dto.request.PhotoRequest;
 import com.dilly.gift.dto.request.StickerRequest;
 import com.dilly.gift.dto.response.GiftBoxIdResponse;
-import com.dilly.gift.dto.response.GiftBoxResponse;
 import com.dilly.global.utils.SecurityUtil;
 import com.dilly.member.Member;
 import com.dilly.member.domain.MemberReader;

--- a/packy-api/src/main/java/com/dilly/gift/application/GiftService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftService.java
@@ -50,7 +50,8 @@ public class GiftService {
         GiftBox giftBox;
         if (giftBoxRequest.gift() == null) {
             giftBox = giftBoxWriter.save(box, letter, sender,
-                giftBoxRequest.name(), giftBoxRequest.youtubeUrl());
+                giftBoxRequest.name(), giftBoxRequest.youtubeUrl(),
+                giftBoxRequest.senderName(), giftBoxRequest.receiverName());
         } else {
             Gift gift = Gift.builder()
                 .giftType(GiftType.valueOf(giftBoxRequest.gift().type().toUpperCase()))
@@ -58,7 +59,8 @@ public class GiftService {
                 .build();
 
             giftBox = giftBoxWriter.save(box, letter, gift, sender,
-                giftBoxRequest.name(), giftBoxRequest.youtubeUrl());
+                giftBoxRequest.name(), giftBoxRequest.youtubeUrl(),
+                giftBoxRequest.senderName(), giftBoxRequest.receiverName());
         }
 
         for (PhotoRequest photoRequest : giftBoxRequest.photos()) {

--- a/packy-api/src/main/java/com/dilly/gift/domain/EnvelopeReader.java
+++ b/packy-api/src/main/java/com/dilly/gift/domain/EnvelopeReader.java
@@ -1,10 +1,10 @@
 package com.dilly.gift.domain;
 
-import com.dilly.admin.dto.response.ImgResponse;
 import com.dilly.exception.ErrorCode;
 import com.dilly.exception.entitynotfound.EntityNotFoundException;
 import com.dilly.gift.Envelope;
 import com.dilly.gift.dao.EnvelopeRepository;
+import com.dilly.gift.dto.response.EnvelopeListResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -15,12 +15,13 @@ public class EnvelopeReader {
 
 	private final EnvelopeRepository envelopeRepository;
 
-	public List<ImgResponse> findAll() {
+	public List<EnvelopeListResponse> findAll() {
 		return envelopeRepository.findAllByOrderBySequenceAsc().stream()
-			.map(envelope -> ImgResponse.builder()
+			.map(envelope -> EnvelopeListResponse.builder()
 				.id(envelope.getId())
 				.imgUrl(envelope.getImgUrl())
 				.sequence(envelope.getSequence())
+				.borderColorCode(envelope.getBorderColorCode())
 				.build())
 			.toList();
 	}

--- a/packy-api/src/main/java/com/dilly/gift/domain/GiftBoxWriter.java
+++ b/packy-api/src/main/java/com/dilly/gift/domain/GiftBoxWriter.java
@@ -17,7 +17,7 @@ public class GiftBoxWriter {
 	private final GiftBoxRepository giftBoxRepository;
 
 	public GiftBox save(Box box, Letter letter, Gift gift, Member member,
-		String name, String youtubeUrl) {
+		String name, String youtubeUrl, String senderName, String receiverName) {
 		return giftBoxRepository.save(GiftBox.builder()
 			.uuid(UUID.randomUUID().toString())
 			.name(name)
@@ -25,12 +25,14 @@ public class GiftBoxWriter {
 			.box(box)
 			.letter(letter)
 			.youtubeUrl(youtubeUrl)
+			.senderName(senderName)
+			.receiverName(receiverName)
 			.gift(gift)
 			.build());
 	}
 
 	public GiftBox save(Box box, Letter letter, Member member,
-		String name, String youtubeUrl) {
+		String name, String youtubeUrl, String senderName, String receiverName) {
 		return giftBoxRepository.save(GiftBox.builder()
 			.uuid(UUID.randomUUID().toString())
 			.name(name)
@@ -38,6 +40,8 @@ public class GiftBoxWriter {
 			.box(box)
 			.letter(letter)
 			.youtubeUrl(youtubeUrl)
+			.senderName(senderName)
+			.receiverName(receiverName)
 			.build());
 	}
 }

--- a/packy-api/src/main/java/com/dilly/gift/dto/response/EnvelopeListResponse.java
+++ b/packy-api/src/main/java/com/dilly/gift/dto/response/EnvelopeListResponse.java
@@ -1,0 +1,18 @@
+package com.dilly.gift.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record EnvelopeListResponse(
+    @Schema(example = "1")
+    Long id,
+    @Schema(example = "1")
+    Long sequence,
+    @Schema(example = "ED76A5")
+    String borderColorCode,
+    @Schema(example = "www.example.com")
+    String imgUrl
+) {
+
+}

--- a/packy-api/src/main/java/com/dilly/gift/dto/response/GiftBoxIdResponse.java
+++ b/packy-api/src/main/java/com/dilly/gift/dto/response/GiftBoxIdResponse.java
@@ -1,0 +1,13 @@
+package com.dilly.gift.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record GiftBoxIdResponse(
+	@Schema(example = "1")
+	Long id,
+	@Schema(example = "550e8400-e29b-41d4-a716-446655440000")
+	String uuid
+) {
+}

--- a/packy-api/src/test/java/com/dilly/admin/api/AdminControllerTest.java
+++ b/packy-api/src/test/java/com/dilly/admin/api/AdminControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.dilly.admin.dto.response.BoxImgResponse;
 import com.dilly.admin.dto.response.ImgResponse;
 import com.dilly.admin.dto.response.MusicResponse;
+import com.dilly.gift.dto.response.EnvelopeListResponse;
 import com.dilly.global.ControllerTestSupport;
 import com.dilly.global.WithCustomMockUser;
 import java.util.List;
@@ -99,10 +100,13 @@ class AdminControllerTest extends ControllerTestSupport {
 	@WithCustomMockUser
 	void getEnvelopes() throws Exception {
 		// given
-		List<ImgResponse> envelopes = List.of(
-			ImgResponse.builder().id(1L).imgUrl("www.test1.com").sequence(1L).build(),
-			ImgResponse.builder().id(2L).imgUrl("www.test2.com").sequence(2L).build(),
-			ImgResponse.builder().id(3L).imgUrl("www.test3.com").sequence(3L).build()
+		List<EnvelopeListResponse> envelopes = List.of(
+			EnvelopeListResponse.builder().id(1L).imgUrl("www.test1.com").sequence(1L)
+				.borderColorCode("ED76A5").build(),
+			EnvelopeListResponse.builder().id(2L).imgUrl("www.test2.com").sequence(2L)
+				.borderColorCode("ED76A5").build(),
+			EnvelopeListResponse.builder().id(3L).imgUrl("www.test3.com").sequence(3L)
+				.borderColorCode("ED76A5").build()
 		);
 
 		given(adminService.getEnvelopes()).willReturn(envelopes);

--- a/packy-api/src/test/java/com/dilly/admin/application/AdminServiceTest.java
+++ b/packy-api/src/test/java/com/dilly/admin/application/AdminServiceTest.java
@@ -6,6 +6,7 @@ import com.dilly.admin.dto.response.BoxImgResponse;
 import com.dilly.admin.dto.response.ImgResponse;
 import com.dilly.admin.dto.response.MusicResponse;
 import com.dilly.gift.MusicHashtag;
+import com.dilly.gift.dto.response.EnvelopeListResponse;
 import com.dilly.global.IntegrationTestSupport;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -57,22 +58,22 @@ class AdminServiceTest extends IntegrationTestSupport {
     @Test
     void getEnvelopes() {
         // given
-        List<ImgResponse> envelopes = envelopeRepository.findAll()
-            .stream().map(envelope -> ImgResponse.builder()
+        List<EnvelopeListResponse> envelopes = envelopeRepository.findAll()
+            .stream().map(envelope -> EnvelopeListResponse.builder()
                 .id(envelope.getId())
                 .imgUrl(envelope.getImgUrl())
                 .sequence(envelope.getSequence())
+                .borderColorCode(envelope.getBorderColorCode())
                 .build()
             ).toList();
 
         // when
-        List<ImgResponse> response = adminService.getEnvelopes();
+        List<EnvelopeListResponse> response = adminService.getEnvelopes();
 
         // then
         assertThat(response).isEqualTo(envelopes);
     }
 
-    @SuppressWarnings("checkstyle:RegexpSinglelineJava")
     @DisplayName("패키 추천 음악을 조회한다.")
     @Test
     void getMusics() {

--- a/packy-api/src/test/java/com/dilly/gift/api/GiftControllerTest.java
+++ b/packy-api/src/test/java/com/dilly/gift/api/GiftControllerTest.java
@@ -11,7 +11,7 @@ import com.dilly.gift.dto.request.GiftBoxRequest;
 import com.dilly.gift.dto.request.GiftRequest;
 import com.dilly.gift.dto.request.PhotoRequest;
 import com.dilly.gift.dto.request.StickerRequest;
-import com.dilly.gift.dto.response.GiftBoxResponse;
+import com.dilly.gift.dto.response.GiftBoxIdResponse;
 import com.dilly.global.ControllerTestSupport;
 import com.dilly.global.WithCustomMockUser;
 import java.util.Collection;
@@ -39,7 +39,7 @@ class GiftControllerTest extends ControllerTestSupport {
         List<StickerRequest> stickers = List.of(
             StickerRequest.builder().id(1L).location(1).build(),
             StickerRequest.builder().id(2L).location(2).build());
-        GiftBoxResponse giftBoxResponse = GiftBoxResponse.builder()
+        GiftBoxIdResponse giftBoxIdResponse = GiftBoxIdResponse.builder()
             .id(1L)
             .uuid("550e8400-e29b-41d4-a716-446655440000")
             .build();
@@ -64,7 +64,7 @@ class GiftControllerTest extends ControllerTestSupport {
                     )
                     .build();
 
-                given(giftService.createGiftBox(giftBoxRequest)).willReturn(giftBoxResponse);
+                given(giftService.createGiftBox(giftBoxRequest)).willReturn(giftBoxIdResponse);
 
                 // when // then
                 mockMvc.perform(
@@ -93,7 +93,7 @@ class GiftControllerTest extends ControllerTestSupport {
                     .gift(null)
                     .build();
 
-                given(giftService.createGiftBox(giftBoxRequest)).willReturn(giftBoxResponse);
+                given(giftService.createGiftBox(giftBoxRequest)).willReturn(giftBoxIdResponse);
 
                 // when // then
                 mockMvc.perform(

--- a/packy-api/src/test/java/com/dilly/gift/application/GiftServiceTest.java
+++ b/packy-api/src/test/java/com/dilly/gift/application/GiftServiceTest.java
@@ -72,6 +72,8 @@ class GiftServiceTest extends IntegrationTestSupport {
                 // then
                 assertThat(giftBox.getBox().getId()).isEqualTo(giftBoxRequest.boxId());
                 assertThat(giftBox.getName()).isEqualTo(giftBoxRequest.name());
+                assertThat(giftBox.getSenderName()).isEqualTo(giftBoxRequest.senderName());
+                assertThat(giftBox.getReceiverName()).isEqualTo(giftBoxRequest.receiverName());
                 assertThat(giftBox.getLetter().getEnvelope().getId()).isEqualTo(
                     giftBoxRequest.envelopeId());
                 assertThat(giftBox.getLetter().getContent()).isEqualTo(
@@ -110,6 +112,8 @@ class GiftServiceTest extends IntegrationTestSupport {
                 // then
                 assertThat(giftBox.getBox().getId()).isEqualTo(giftBoxRequest.boxId());
                 assertThat(giftBox.getName()).isEqualTo(giftBoxRequest.name());
+                assertThat(giftBox.getSenderName()).isEqualTo(giftBoxRequest.senderName());
+                assertThat(giftBox.getReceiverName()).isEqualTo(giftBoxRequest.receiverName());
                 assertThat(giftBox.getLetter().getEnvelope().getId()).isEqualTo(
                     giftBoxRequest.envelopeId());
                 assertThat(giftBox.getLetter().getContent()).isEqualTo(

--- a/packy-api/src/test/java/com/dilly/gift/application/GiftServiceTest.java
+++ b/packy-api/src/test/java/com/dilly/gift/application/GiftServiceTest.java
@@ -10,7 +10,7 @@ import com.dilly.gift.dto.request.GiftBoxRequest;
 import com.dilly.gift.dto.request.GiftRequest;
 import com.dilly.gift.dto.request.PhotoRequest;
 import com.dilly.gift.dto.request.StickerRequest;
-import com.dilly.gift.dto.response.GiftBoxResponse;
+import com.dilly.gift.dto.response.GiftBoxIdResponse;
 import com.dilly.global.IntegrationTestSupport;
 import com.dilly.global.WithCustomMockUser;
 import com.dilly.global.utils.SecurityUtil;
@@ -65,7 +65,7 @@ class GiftServiceTest extends IntegrationTestSupport {
                     .build();
 
                 // when
-                GiftBoxResponse giftBoxResponse = giftService.createGiftBox(giftBoxRequest);
+                GiftBoxIdResponse giftBoxIdResponse = giftService.createGiftBox(giftBoxRequest);
                 GiftBox giftBox = giftBoxRepository.findTopByOrderByIdDesc();
                 List<Photo> photos = photoRepository.findAllByGiftBox(giftBox);
 
@@ -85,8 +85,8 @@ class GiftServiceTest extends IntegrationTestSupport {
                     .contains(tuple("www.test1.com", "description1", 1),
                         tuple("www.test2.com", "description2", 2));
 
-                assertThat(giftBoxResponse.id()).isEqualTo(giftBox.getId());
-                assertTrue(isValidUUID(giftBoxResponse.uuid()));
+                assertThat(giftBoxIdResponse.id()).isEqualTo(giftBox.getId());
+                assertTrue(isValidUUID(giftBoxIdResponse.uuid()));
             }),
             DynamicTest.dynamicTest("선물이 없을 경우", () -> {
                 //given
@@ -103,7 +103,7 @@ class GiftServiceTest extends IntegrationTestSupport {
                     .build();
 
                 // when
-                GiftBoxResponse giftBoxResponse = giftService.createGiftBox(giftBoxRequest);
+                GiftBoxIdResponse giftBoxIdResponse = giftService.createGiftBox(giftBoxRequest);
                 GiftBox giftBox = giftBoxRepository.findTopByOrderByIdDesc();
                 List<Photo> photos = photoRepository.findAllByGiftBox(giftBox);
 
@@ -121,8 +121,8 @@ class GiftServiceTest extends IntegrationTestSupport {
                     .contains(tuple("www.test1.com", "description1", 1),
                         tuple("www.test2.com", "description2", 2));
 
-                assertThat(giftBoxResponse.id()).isEqualTo(giftBox.getId());
-                assertTrue(isValidUUID(giftBoxResponse.uuid()));
+                assertThat(giftBoxIdResponse.id()).isEqualTo(giftBox.getId());
+                assertTrue(isValidUUID(giftBoxIdResponse.uuid()));
             })
         );
     }

--- a/packy-domain/src/main/java/com/dilly/gift/Envelope.java
+++ b/packy-domain/src/main/java/com/dilly/gift/Envelope.java
@@ -1,6 +1,6 @@
 package com.dilly.gift;
 
-import static jakarta.persistence.GenerationType.*;
+import static jakarta.persistence.GenerationType.IDENTITY;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -16,6 +16,8 @@ public class Envelope {
 	private Long id;
 
 	private Long sequence;
+
+	private String borderColorCode;
 
 	private String imgUrl;
 }

--- a/packy-domain/src/main/java/com/dilly/gift/GiftBox.java
+++ b/packy-domain/src/main/java/com/dilly/gift/GiftBox.java
@@ -6,6 +6,8 @@ import com.dilly.global.BaseTimeEntity;
 import com.dilly.member.Member;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -32,6 +34,7 @@ public class GiftBox extends BaseTimeEntity {
     private String name;
 
     private String senderName;
+
     private String receiverName;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -48,4 +51,7 @@ public class GiftBox extends BaseTimeEntity {
 
     @Embedded
     private Gift gift;
+
+    @Enumerated(EnumType.STRING)
+    private GiftBoxType giftBoxType;
 }

--- a/packy-domain/src/main/java/com/dilly/gift/GiftBox.java
+++ b/packy-domain/src/main/java/com/dilly/gift/GiftBox.java
@@ -31,6 +31,9 @@ public class GiftBox extends BaseTimeEntity {
 
     private String name;
 
+    private String senderName;
+    private String receiverName;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sender_id")
     private Member sender;

--- a/packy-domain/src/main/java/com/dilly/gift/GiftBoxType.java
+++ b/packy-domain/src/main/java/com/dilly/gift/GiftBoxType.java
@@ -1,0 +1,7 @@
+package com.dilly.gift;
+
+public enum GiftBoxType {
+    PRIVATE,
+    SEMI_PUBLIC,
+    PUBLIC
+}

--- a/packy-domain/src/main/resources/db/migration/V21__add_sender_receiver_name_in_gift_box_table.sql
+++ b/packy-domain/src/main/resources/db/migration/V21__add_sender_receiver_name_in_gift_box_table.sql
@@ -1,0 +1,5 @@
+alter table gift_box
+add column sender_name varchar(255);
+
+alter table gift_box
+add column receiver_name varchar(255);

--- a/packy-domain/src/main/resources/db/migration/V22__add_border_color_code_in_envelope_table.sql
+++ b/packy-domain/src/main/resources/db/migration/V22__add_border_color_code_in_envelope_table.sql
@@ -1,0 +1,2 @@
+alter table envelope
+add column border_color_code varchar(255);

--- a/packy-domain/src/main/resources/db/migration/V23__add_gift_box_type_in_gift_box_table.sql
+++ b/packy-domain/src/main/resources/db/migration/V23__add_gift_box_type_in_gift_box_table.sql
@@ -1,0 +1,3 @@
+-- gift_box 테이블에 새로운 컬럼 추가
+ALTER TABLE gift_box
+ADD COLUMN gift_box_type enum('PRIVATE', 'SEMI_PUBLIC', 'PUBLIC') NOT NULL DEFAULT 'PRIVATE';


### PR DESCRIPTION
## 🛰️ Issue Number
X

## 🪐 작업 내용
선물박스 열어보기 API를 구현하기 이전에 기존에 놓쳤던 기획을 반영할 수 있도록 GiftBox와 Envelope 엔티티를 수정하였습니다.

- 선물박스 열어보기 API에서 선물박스를 나타내는 Response DTO를 만들기 위해 선물박스 만들기 API의 Response DTO를 GiftBoxIdResponse로 클래스명을 변경하였습니다.
- GiftBox 엔티티에 보내는 사람, 받는 사람 컬럼을 추가하였습니다.
- Envelope 엔티티에 편지 봉투 테두리 색을 나타내는 색상 코드 컬럼을 추가하였습니다.
- 확장성을 고려하여 GiftBox 엔티티에 선물박스의 열기 제한을 나타내는 enum 타입을 추가하였습니다.

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [ ] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
