### PR TITLE
fix: S3 Presigned URL 발급 시 파일 이름 인코딩 추가

### DIFF
--- a/packy-common/src/main/java/com/dilly/exception/ErrorCode.java
+++ b/packy-common/src/main/java/com/dilly/exception/ErrorCode.java
@@ -31,6 +31,8 @@ public enum ErrorCode {
     APPLE_FAILED_TO_REVOKE_ACCOUNT(HttpStatus.INTERNAL_SERVER_ERROR, "애플 계정을 해지하는데 실패했습니다."),
     // Youtube
     YOUTUBE_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "유튜브 서버 연동에 오류가 발생했습니다."),
+    // File
+    FILE_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파일 서버 연동에 오류가 발생했습니다."),
 
     // Authorization
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),


### PR DESCRIPTION
## 🛰️ Issue Number
#90 

## 🪐 작업 내용
Presigned URL을 만들 때 파일 이름을 UTF-8로 인코딩하는 코드를 추가하였습니다.

## 📚 Reference
- https://reference-m1.tistory.com/398

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
