### PR TITLE
feat: 받은 선물박스 조회 API 구현

### DIFF
--- a/packy-api/src/main/java/com/dilly/admin/api/AdminController.java
+++ b/packy-api/src/main/java/com/dilly/admin/api/AdminController.java
@@ -66,6 +66,7 @@ public class AdminController {
         return DataResponseDto.from(adminService.getMusics());
     }
 
+    // TODO: sequence 순으로 페이징
     @Operation(summary = "스티커 조회")
     @Parameter(in = ParameterIn.QUERY
         , description = "한 페이지에 보여줄 스티커 개수. 기본값은 10개"

--- a/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
+++ b/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
@@ -50,7 +50,6 @@ public class GiftBoxController {
         return DataResponseDto.from(giftBoxService.createGiftBox(giftBoxRequest));
     }
 
-    // TODO: sequence 순으로 페이징 정렬 변경
     @Operation(summary = "선물박스 열기", description = """
         1. 선물이 없을 경우 응답에서 gift 객체가 제외됩니다.
         2. 이미 열린 선물박스는 다른 사람이 열 수 없습니다.

--- a/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
+++ b/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
@@ -65,7 +65,7 @@ public class GiftBoxController {
         return DataResponseDto.from(giftBoxService.openGiftBox(giftBoxId));
     }
 
-    @Operation(summary = "주고받은 선물박스")
+    @Operation(summary = "주고받은 선물박스 조회")
     @Parameter(in = ParameterIn.QUERY
         , description = "한 페이지에 보여줄 선물박스 개수. 기본값은 6개"
         , name = "size"

--- a/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
@@ -116,6 +116,7 @@ public class GiftBoxService {
             throw new GiftBoxAlreadyOpenedException();
         }
 
+        // 선물박스를 이전에 열지 않았던 경우
         if (!receivers.contains(receiver.getId())) {
             receiverWriter.save(receiver, giftBox);
         }

--- a/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
@@ -150,7 +150,7 @@ public class GiftBoxService {
             pageable);
 
         List<GiftBoxesResponse> giftBoxesResponses = giftBoxSlice.getContent().stream()
-            .map(giftBox -> GiftBoxesResponse.of(giftBox, type))
+            .map(GiftBoxesResponse::of)
             .toList();
 
         return new SliceImpl<>(giftBoxesResponses, pageable, giftBoxSlice.hasNext());

--- a/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
@@ -105,7 +105,7 @@ public class GiftBoxService {
         GiftBox giftBox = giftBoxReader.findById(giftBoxId);
 
         List<Long> receivers = receiverReader.findByGiftBox(giftBox).stream()
-            .map(Receiver::getReceiver)
+            .map(Receiver::getMember)
             .map(Member::getId)
             .toList();
 

--- a/packy-api/src/main/java/com/dilly/gift/dto/response/GiftBoxesResponse.java
+++ b/packy-api/src/main/java/com/dilly/gift/dto/response/GiftBoxesResponse.java
@@ -13,9 +13,7 @@ public record GiftBoxesResponse(
     String boxFull
 ) {
 
-    // TODO: type이 received라면 giftboxDate가 Receiver의 createdAt
-    // TODO: type이 없다면 내가 보낸 선물박스랑 내가 받은 선물박스를 합치고 giftboxDate로 정렬
-    public static GiftBoxesResponse of(GiftBox giftBox, String type) {
+    public static GiftBoxesResponse of(GiftBox giftBox) {
         return GiftBoxesResponse.builder()
             .id(giftBox.getId())
             .sender(giftBox.getSenderName())

--- a/packy-api/src/test/java/com/dilly/gift/application/GiftBoxServiceTest.java
+++ b/packy-api/src/test/java/com/dilly/gift/application/GiftBoxServiceTest.java
@@ -185,7 +185,7 @@ class GiftBoxServiceTest extends IntegrationTestSupport {
                 // then
                 assertThat(receiverAfter).isEqualTo(receiverBefore + 1);
                 assertThat(receivers).hasSize(1)
-                    .extracting("receiver.id").contains(member2.getId());
+                    .extracting("member.id").contains(member2.getId());
 
                 assertThat(giftBoxResponse.name()).isEqualTo(giftBoxWithGift.getName());
                 assertThat(giftBoxResponse.senderName()).isEqualTo(giftBoxWithGift.getSenderName());
@@ -227,7 +227,7 @@ class GiftBoxServiceTest extends IntegrationTestSupport {
                 // then
                 assertThat(receiverAfter).isEqualTo(receiverBefore + 1);
                 assertThat(receivers).hasSize(1)
-                    .extracting("receiver.id").contains(member2.getId());
+                    .extracting("member.id").contains(member2.getId());
                 assertThat(giftBoxResponse.name()).isEqualTo(giftBoxWithoutGift.getName());
                 assertThat(giftBoxResponse.senderName()).isEqualTo(
                     giftBoxWithoutGift.getSenderName());
@@ -277,7 +277,7 @@ class GiftBoxServiceTest extends IntegrationTestSupport {
                 // then
                 assertThat(receiverAfter).isEqualTo(receiverBefore);
                 assertThat(receivers).hasSize(1)
-                    .extracting("receiver.id").contains(member2.getId());
+                    .extracting("member.id").contains(member2.getId());
                 assertThat(giftBoxResponse.name()).isEqualTo(giftBox.getName());
                 assertThat(giftBoxResponse.senderName()).isEqualTo(
                     giftBox.getSenderName());

--- a/packy-api/src/test/java/com/dilly/global/IntegrationTestSupport.java
+++ b/packy-api/src/test/java/com/dilly/global/IntegrationTestSupport.java
@@ -140,7 +140,7 @@ public abstract class IntegrationTestSupport {
 
     protected void openGiftBox(Member member, GiftBox giftBox) {
         List<Member> receivers = receiver.findByGiftBox(giftBox).stream()
-            .map(Receiver::getReceiver)
+            .map(Receiver::getMember)
             .toList();
 
         if (!receivers.contains(member)) {

--- a/packy-domain/src/main/java/com/dilly/gift/adaptor/ReceiverWriter.java
+++ b/packy-domain/src/main/java/com/dilly/gift/adaptor/ReceiverWriter.java
@@ -14,9 +14,6 @@ public class ReceiverWriter {
     private final ReceiverRepository receiverRepository;
 
     public void save(Member member, GiftBox giftBox) {
-        receiverRepository.save(Receiver.builder()
-            .member(member)
-            .giftBox(giftBox)
-            .build());
+        receiverRepository.save(Receiver.of(member, giftBox));
     }
 }

--- a/packy-domain/src/main/java/com/dilly/gift/adaptor/ReceiverWriter.java
+++ b/packy-domain/src/main/java/com/dilly/gift/adaptor/ReceiverWriter.java
@@ -15,7 +15,7 @@ public class ReceiverWriter {
 
     public void save(Member member, GiftBox giftBox) {
         receiverRepository.save(Receiver.builder()
-            .receiver(member)
+            .member(member)
             .giftBox(giftBox)
             .build());
     }

--- a/packy-domain/src/main/java/com/dilly/gift/dao/querydsl/GiftBoxQueryRepository.java
+++ b/packy-domain/src/main/java/com/dilly/gift/dao/querydsl/GiftBoxQueryRepository.java
@@ -1,6 +1,7 @@
 package com.dilly.gift.dao.querydsl;
 
 import static com.dilly.gift.domain.QGiftBox.giftBox;
+import static com.dilly.gift.domain.QReceiver.receiver;
 
 import com.dilly.gift.domain.GiftBox;
 import com.dilly.member.domain.Member;
@@ -25,6 +26,7 @@ public class GiftBoxQueryRepository {
         Pageable pageable) {
         List<GiftBox> results = new ArrayList<>();
 
+        // TODO: switch문으로 리팩토링
         if (type.equals("sent")) {
             results = jpaQueryFactory.selectFrom(giftBox)
                 .limit(pageable.getPageSize() + 1L)
@@ -35,7 +37,15 @@ public class GiftBoxQueryRepository {
                 .limit(pageable.getPageSize() + 1L)
                 .fetch();
         } else if (type.equals("received")) {
-            // TODO: type이 received라면 giftboxDate가 Receiver의 createdAt
+            results = jpaQueryFactory.select(giftBox)
+                .from(receiver)
+                .join(receiver.giftBox, giftBox)
+                .where(
+                    ltGiftBoxDate(lastGiftBoxDate),
+                    receiver.member.eq(member))
+                .orderBy(receiver.createdAt.desc())
+                .limit(pageable.getPageSize() + 1L)
+                .fetch();
         } else if (type.equals("all")) {
             // TODO: type이 없다면 내가 보낸 선물박스랑 내가 받은 선물박스를 합치고 giftboxDate로 정렬
         }

--- a/packy-domain/src/main/java/com/dilly/gift/domain/Receiver.java
+++ b/packy-domain/src/main/java/com/dilly/gift/domain/Receiver.java
@@ -32,4 +32,11 @@ public class Receiver extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private GiftBox giftBox;
+
+    public static Receiver of(Member member, GiftBox giftBox) {
+        return Receiver.builder()
+            .member(member)
+            .giftBox(giftBox)
+            .build();
+    }
 }

--- a/packy-domain/src/main/java/com/dilly/gift/domain/Receiver.java
+++ b/packy-domain/src/main/java/com/dilly/gift/domain/Receiver.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,7 +27,8 @@ public class Receiver extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private Member receiver;
+    @JoinColumn(name = "receiver_id")
+    private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private GiftBox giftBox;

--- a/packy-domain/src/test/java/com/dilly/global/RepositoryTestSupport.java
+++ b/packy-domain/src/test/java/com/dilly/global/RepositoryTestSupport.java
@@ -70,7 +70,7 @@ public abstract class RepositoryTestSupport {
     @Autowired
     protected ProfileImageRepository profileImageRepository;
 
-    protected void createMockGiftBoxWithGift(Member member) {
+    protected void createMockGiftBox(Member member) {
         Box box = boxRepository.findById(1L).orElseThrow();
         Envelope envelope = envelopeRepository.findById(1L).orElseThrow();
         Letter letter = letterRepository.save(Letter.of("test", envelope));


### PR DESCRIPTION
## 🛰️ Issue Number
#96 

## 🪐 작업 내용
- 받은 선물박스 조회 API를 구현하였습니다. 5b29007e42318dde6076a1486aae4e356e970b23
  - Receiver 엔티티에서 필드명이 receiver일 경우 QueryDsl 메서드 사용에 불편함이 있어 member로 변경했습니다. f1239ce971e368eee03ba637cfd3f67a253cc907
- 보낸 선물박스 조회 API의 Repository 테스트 코드를 리팩토링했습니다. 1f86b84eefe31098ecec46b2e0bfadcf07d186d0

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [ ] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
