### PR TITLE
feat: 설정 링크 조회 API

### DIFF
--- a/packy-api/src/main/java/com/dilly/admin/api/AdminController.java
+++ b/packy-api/src/main/java/com/dilly/admin/api/AdminController.java
@@ -4,6 +4,7 @@ import com.dilly.admin.application.AdminService;
 import com.dilly.admin.dto.response.BoxImgResponse;
 import com.dilly.admin.dto.response.ImgResponse;
 import com.dilly.admin.dto.response.MusicResponse;
+import com.dilly.admin.dto.response.SettingResponse;
 import com.dilly.application.YoutubeService;
 import com.dilly.dto.response.StatusResponse;
 import com.dilly.exception.ErrorCode;
@@ -92,5 +93,17 @@ public class AdminController {
         @RequestParam(value = "url", required = true)
         String url) {
         return DataResponseDto.from(youtubeService.validateYoutubeUrl(url));
+    }
+
+    @Operation(summary = "설정 링크 조회", description = """
+        패키 공식 SNS: OFFICIAL_SNS <br>
+        1:1 문의하기: INQUIRY <br>
+        패키에게 의견 보내기: SEND_COMMENT <br>
+        이용약관: TERMS_OF_USE <br>
+        개인정보처리방침: PRIVACY_POLICY <br>
+        """)
+    @GetMapping("/settings")
+    public DataResponseDto<List<SettingResponse>> getSettingUrls() {
+        return DataResponseDto.from(adminService.getSettingUrls());
     }
 }

--- a/packy-api/src/main/java/com/dilly/admin/application/AdminService.java
+++ b/packy-api/src/main/java/com/dilly/admin/application/AdminService.java
@@ -1,8 +1,11 @@
 package com.dilly.admin.application;
 
+import com.dilly.admin.adaptor.SettingReader;
+import com.dilly.admin.domain.Setting;
 import com.dilly.admin.dto.response.BoxImgResponse;
 import com.dilly.admin.dto.response.ImgResponse;
 import com.dilly.admin.dto.response.MusicResponse;
+import com.dilly.admin.dto.response.SettingResponse;
 import com.dilly.gift.adaptor.BoxReader;
 import com.dilly.gift.adaptor.EnvelopeReader;
 import com.dilly.gift.adaptor.MusicReader;
@@ -34,6 +37,7 @@ public class AdminService {
     private final EnvelopeReader envelopeReader;
     private final MusicReader musicReader;
     private final StickerReader stickerReader;
+    private final SettingReader settingReader;
 
     public List<ImgResponse> getProfiles() {
         List<ProfileImage> profileImages = profileImageReader.findAllByOrderBySequenceAsc();
@@ -66,5 +70,11 @@ public class AdminService {
             .toList();
 
         return new SliceImpl<>(imgResponses, pageable, stickerSlice.hasNext());
+    }
+
+    public List<SettingResponse> getSettingUrls() {
+        List<Setting> settingUrls = settingReader.findAll();
+
+        return settingUrls.stream().map(SettingResponse::from).toList();
     }
 }

--- a/packy-api/src/main/java/com/dilly/admin/application/AdminService.java
+++ b/packy-api/src/main/java/com/dilly/admin/application/AdminService.java
@@ -42,31 +42,31 @@ public class AdminService {
     public List<ImgResponse> getProfiles() {
         List<ProfileImage> profileImages = profileImageReader.findAllByOrderBySequenceAsc();
 
-        return profileImages.stream().map(ImgResponse::of).toList();
+        return profileImages.stream().map(ImgResponse::from).toList();
     }
 
     public List<BoxImgResponse> getBoxes() {
         List<Box> boxes = boxReader.findAllByOrderBySequenceAsc();
 
-        return boxes.stream().map(BoxImgResponse::of).toList();
+        return boxes.stream().map(BoxImgResponse::from).toList();
     }
 
     public List<EnvelopeListResponse> getEnvelopes() {
         List<Envelope> envelopes = envelopeReader.findAllByOrderBySequenceAsc();
 
-        return envelopes.stream().map(EnvelopeListResponse::of).toList();
+        return envelopes.stream().map(EnvelopeListResponse::from).toList();
     }
 
     public List<MusicResponse> getMusics() {
         List<Music> musics = musicReader.findAllByOrderBySequenceAsc();
 
-        return musics.stream().map(MusicResponse::of).toList();
+        return musics.stream().map(MusicResponse::from).toList();
     }
 
     public Slice<ImgResponse> getStickers(Long lastStickerId, Pageable pageable) {
         Slice<Sticker> stickerSlice = stickerReader.searchBySlice(lastStickerId, pageable);
         List<ImgResponse> imgResponses = stickerSlice.getContent().stream()
-            .map(ImgResponse::of)
+            .map(ImgResponse::from)
             .toList();
 
         return new SliceImpl<>(imgResponses, pageable, stickerSlice.hasNext());

--- a/packy-api/src/main/java/com/dilly/admin/dto/response/BoxImgResponse.java
+++ b/packy-api/src/main/java/com/dilly/admin/dto/response/BoxImgResponse.java
@@ -18,7 +18,7 @@ public record BoxImgResponse(
 	String boxBottom
 ) {
 
-    public static BoxImgResponse of(Box box) {
+	public static BoxImgResponse from(Box box) {
         return BoxImgResponse.builder()
             .id(box.getId())
             .sequence(box.getSequence())

--- a/packy-api/src/main/java/com/dilly/admin/dto/response/ImgResponse.java
+++ b/packy-api/src/main/java/com/dilly/admin/dto/response/ImgResponse.java
@@ -15,7 +15,7 @@ public record ImgResponse(
 	String imgUrl
 ) {
 
-	public static ImgResponse of(ProfileImage profileImage) {
+	public static ImgResponse from(ProfileImage profileImage) {
 		return ImgResponse.builder()
 			.id(profileImage.getId())
 			.sequence(profileImage.getSequence())
@@ -23,7 +23,7 @@ public record ImgResponse(
 			.build();
 	}
 
-	public static ImgResponse of(Sticker sticker) {
+	public static ImgResponse from(Sticker sticker) {
 		return ImgResponse.builder()
 			.id(sticker.getId())
 			.sequence(sticker.getSequence())

--- a/packy-api/src/main/java/com/dilly/admin/dto/response/MusicResponse.java
+++ b/packy-api/src/main/java/com/dilly/admin/dto/response/MusicResponse.java
@@ -19,7 +19,7 @@ public record MusicResponse(
 	List<String> hashtags
 ) {
 
-	public static MusicResponse of(Music music) {
+	public static MusicResponse from(Music music) {
 		return MusicResponse.builder()
 			.id(music.getId())
 			.youtubeUrl(music.getYoutubeUrl())

--- a/packy-api/src/main/java/com/dilly/admin/dto/response/SettingResponse.java
+++ b/packy-api/src/main/java/com/dilly/admin/dto/response/SettingResponse.java
@@ -1,0 +1,18 @@
+package com.dilly.admin.dto.response;
+
+import com.dilly.admin.domain.Setting;
+import lombok.Builder;
+
+@Builder
+public record SettingResponse(
+    String tag,
+    String url
+) {
+
+    public static SettingResponse from(Setting setting) {
+        return SettingResponse.builder()
+            .tag(setting.getSettingTag().toString())
+            .url(setting.getUrl())
+            .build();
+    }
+}

--- a/packy-api/src/main/java/com/dilly/gift/dto/response/EnvelopeListResponse.java
+++ b/packy-api/src/main/java/com/dilly/gift/dto/response/EnvelopeListResponse.java
@@ -16,7 +16,7 @@ public record EnvelopeListResponse(
     String imgUrl
 ) {
 
-    public static EnvelopeListResponse of(Envelope envelope) {
+    public static EnvelopeListResponse from(Envelope envelope) {
         return EnvelopeListResponse.builder()
             .id(envelope.getId())
             .sequence(envelope.getSequence())

--- a/packy-api/src/test/java/com/dilly/admin/api/AdminControllerTest.java
+++ b/packy-api/src/test/java/com/dilly/admin/api/AdminControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.dilly.admin.dto.response.BoxImgResponse;
 import com.dilly.admin.dto.response.ImgResponse;
 import com.dilly.admin.dto.response.MusicResponse;
+import com.dilly.admin.dto.response.SettingResponse;
 import com.dilly.gift.dto.response.EnvelopeListResponse;
 import com.dilly.global.ControllerTestSupport;
 import com.dilly.global.WithCustomMockUser;
@@ -143,5 +144,28 @@ class AdminControllerTest extends ControllerTestSupport {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data").isArray())
 			.andExpect(jsonPath("$.data", hasSize(2)));
+	}
+
+	@DisplayName("설정 링크를 조회한다.")
+	@Test
+	@WithCustomMockUser
+	void getSettingUrls() throws Exception {
+		// given
+		List<SettingResponse> settingResponses = List.of(
+			SettingResponse.builder().tag("TEST1").url("www.test1.com").build(),
+			SettingResponse.builder().tag("TEST2").url("www.test2.com").build(),
+			SettingResponse.builder().tag("TEST3").url("www.test3.com").build()
+		);
+
+		given(adminService.getSettingUrls()).willReturn(settingResponses);
+
+		// when // then
+		mockMvc.perform(
+				get(baseUrl + "/admin/settings")
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data").isArray())
+			.andExpect(jsonPath("$.data", hasSize(3)));
 	}
 }

--- a/packy-api/src/test/java/com/dilly/admin/application/AdminServiceTest.java
+++ b/packy-api/src/test/java/com/dilly/admin/application/AdminServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.dilly.admin.dto.response.BoxImgResponse;
 import com.dilly.admin.dto.response.ImgResponse;
 import com.dilly.admin.dto.response.MusicResponse;
+import com.dilly.admin.dto.response.SettingResponse;
 import com.dilly.gift.domain.MusicHashtag;
 import com.dilly.gift.dto.response.EnvelopeListResponse;
 import com.dilly.global.IntegrationTestSupport;
@@ -93,5 +94,20 @@ class AdminServiceTest extends IntegrationTestSupport {
 
         // then
         assertThat(response).isEqualTo(musics);
+    }
+
+    @DisplayName("설정 링크를 조회한다.")
+    @Test
+    void getSettingUrls() {
+        // given
+        List<SettingResponse> settingUrls = settingRepository.findAll()
+            .stream().map(SettingResponse::from)
+            .toList();
+
+        // when
+        List<SettingResponse> response = adminService.getSettingUrls();
+
+        // then
+        assertThat(response).isEqualTo(settingUrls);
     }
 }

--- a/packy-api/src/test/java/com/dilly/admin/application/AdminServiceTest.java
+++ b/packy-api/src/test/java/com/dilly/admin/application/AdminServiceTest.java
@@ -6,7 +6,6 @@ import com.dilly.admin.dto.response.BoxImgResponse;
 import com.dilly.admin.dto.response.ImgResponse;
 import com.dilly.admin.dto.response.MusicResponse;
 import com.dilly.admin.dto.response.SettingResponse;
-import com.dilly.gift.domain.MusicHashtag;
 import com.dilly.gift.dto.response.EnvelopeListResponse;
 import com.dilly.global.IntegrationTestSupport;
 import java.util.List;
@@ -20,12 +19,7 @@ class AdminServiceTest extends IntegrationTestSupport {
     void getProfiles() {
         // given
         List<ImgResponse> profiles = profileImageRepository.findAll()
-            .stream().map(profileImage -> ImgResponse.builder()
-                .id(profileImage.getId())
-                .imgUrl(profileImage.getImgUrl())
-                .sequence(profileImage.getSequence())
-                .build()
-            ).toList();
+            .stream().map(ImgResponse::from).toList();
 
         // when
         List<ImgResponse> response = adminService.getProfiles();
@@ -39,14 +33,7 @@ class AdminServiceTest extends IntegrationTestSupport {
     void getBoxes() {
         // given
         List<BoxImgResponse> boxes = boxRepository.findAll()
-            .stream().map(box -> BoxImgResponse.builder()
-                .id(box.getId())
-                .boxFull(box.getFullImgUrl())
-                .boxPart(box.getPartImgUrl())
-                .boxBottom(box.getBottomImgUrl())
-                .sequence(box.getSequence())
-                .build()
-            ).toList();
+            .stream().map(BoxImgResponse::from).toList();
 
         // when
         List<BoxImgResponse> response = adminService.getBoxes();
@@ -60,13 +47,7 @@ class AdminServiceTest extends IntegrationTestSupport {
     void getEnvelopes() {
         // given
         List<EnvelopeListResponse> envelopes = envelopeRepository.findAll()
-            .stream().map(envelope -> EnvelopeListResponse.builder()
-                .id(envelope.getId())
-                .imgUrl(envelope.getImgUrl())
-                .sequence(envelope.getSequence())
-                .borderColorCode(envelope.getBorderColorCode())
-                .build()
-            ).toList();
+            .stream().map(EnvelopeListResponse::from).toList();
 
         // when
         List<EnvelopeListResponse> response = adminService.getEnvelopes();
@@ -80,14 +61,8 @@ class AdminServiceTest extends IntegrationTestSupport {
     void getMusics() {
         // given
         List<MusicResponse> musics = musicRepository.findAll()
-            .stream().map(music -> MusicResponse.builder()
-                .id(music.getId())
-                .sequence(music.getSequence())
-                .title(music.getTitle())
-                .youtubeUrl(music.getYoutubeUrl())
-                .hashtags(music.getHashtags().stream().map(MusicHashtag::getHashtag).toList())
-                .build()
-            ).toList();
+            .stream().map(MusicResponse::from)
+            .toList();
 
         // when
         List<MusicResponse> response = adminService.getMusics();

--- a/packy-api/src/test/java/com/dilly/global/IntegrationTestSupport.java
+++ b/packy-api/src/test/java/com/dilly/global/IntegrationTestSupport.java
@@ -1,6 +1,7 @@
 package com.dilly.global;
 
 import com.dilly.admin.application.AdminService;
+import com.dilly.admin.dao.SettingRepository;
 import com.dilly.gift.adaptor.GiftBoxWriter;
 import com.dilly.gift.adaptor.PhotoWriter;
 import com.dilly.gift.adaptor.ReceiverReader;
@@ -101,6 +102,9 @@ public abstract class IntegrationTestSupport {
     @Autowired
     protected MemberRepository memberRepository;
 
+    @Autowired
+    protected SettingRepository settingRepository;
+
     protected GiftBox createMockGiftBoxWithGift(Member member) {
         Box box = boxRepository.findById(1L).orElseThrow();
         Envelope envelope = envelopeRepository.findById(1L).orElseThrow();
@@ -115,8 +119,6 @@ public abstract class IntegrationTestSupport {
             Sticker sticker = stickerRepository.findById(i).orElseThrow();
             giftBoxStickerRepository.save(GiftBoxSticker.of(giftBox, sticker, (int) i));
         }
-
-        giftBoxRepository.flush();
 
         return giftBox;
     }

--- a/packy-domain/src/main/java/com/dilly/admin/adaptor/SettingReader.java
+++ b/packy-domain/src/main/java/com/dilly/admin/adaptor/SettingReader.java
@@ -1,0 +1,18 @@
+package com.dilly.admin.adaptor;
+
+import com.dilly.admin.dao.SettingRepository;
+import com.dilly.admin.domain.Setting;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SettingReader {
+
+    private final SettingRepository settingRepository;
+
+    public List<Setting> findAll() {
+        return settingRepository.findAll();
+    }
+}

--- a/packy-domain/src/main/java/com/dilly/admin/dao/SettingRepository.java
+++ b/packy-domain/src/main/java/com/dilly/admin/dao/SettingRepository.java
@@ -1,0 +1,8 @@
+package com.dilly.admin.dao;
+
+import com.dilly.admin.domain.Setting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SettingRepository extends JpaRepository<Setting, Long> {
+
+}

--- a/packy-domain/src/main/java/com/dilly/admin/domain/Setting.java
+++ b/packy-domain/src/main/java/com/dilly/admin/domain/Setting.java
@@ -1,0 +1,23 @@
+package com.dilly.admin.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Setting {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private SettingTag settingTag;
+
+    private String url;
+}

--- a/packy-domain/src/main/java/com/dilly/admin/domain/SettingTag.java
+++ b/packy-domain/src/main/java/com/dilly/admin/domain/SettingTag.java
@@ -1,0 +1,9 @@
+package com.dilly.admin.domain;
+
+public enum SettingTag {
+    OFFICIAL_SNS,
+    INQUIRY,
+    SEND_COMMENT,
+    TERMS_OF_USE,
+    PRIVACY_POLICY
+}

--- a/packy-domain/src/main/resources/db/migration/V24__add_setting_table.sql
+++ b/packy-domain/src/main/resources/db/migration/V24__add_setting_table.sql
@@ -1,0 +1,6 @@
+create table setting (
+    id bigint not null auto_increment,
+    url varchar(255),
+    setting_tag enum ('OFFICIAL_SNS','INQUIRY','SEND_COMMENT','TERMS_OF_USE','PRIVACY_POLICY'),
+    primary key (id)
+ );


### PR DESCRIPTION
## 🛰️ Issue Number
#101 

## 🪐 작업 내용
- 설정 링크 조회 API를 구현하고 Controller, Service 테스트 코드를 작성하였습니다. 10bff656afaedf074a526347aab91b74dfba6e68 b8cc5fad120165f44abdb904094c075365a9716c ec8593fc08079ec9e1849823f1bf51cb73228fc6
- 정적 팩토리 메서드에서 인자의 개수에 따라 하나라면 from, 여러개면 of로 명명합니다. 인자가 하나인데 of로 되어있는 메서드명을 from으로 변경하였습니다.

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
