### PR TITLE
fix: 애플로그인 시 authorization_code 대신 identityToken을 받도록 로직 변경

### DIFF
--- a/.github/workflows/packy-ci.yml
+++ b/.github/workflows/packy-ci.yml
@@ -25,7 +25,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Run build with Gradle Wrapper
         run: ./gradlew clean build

--- a/.github/workflows/packy-ci.yml
+++ b/.github/workflows/packy-ci.yml
@@ -19,13 +19,13 @@ jobs:
           submodules: true
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
 
       - name: Run build with Gradle Wrapper
         run: ./gradlew clean build

--- a/packy-api/src/main/java/com/dilly/auth/application/AuthService.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/AuthService.java
@@ -105,8 +105,9 @@ public class AuthService {
 			}
 
 			case "apple" -> {
-				AppleToken appleToken = appleService.getAppleToken(providerAccessToken);
-				AppleAccountInfo appleAccountInfo = appleService.getAppleAccountInfo(appleToken.idToken());
+				// identityToken을 받아 회원 정보 조회
+				AppleAccountInfo appleAccountInfo = appleService.getAppleAccountInfo(
+					providerAccessToken);
 				member = appleAccountReader.getMemberById(appleAccountInfo.sub());
 			}
 


### PR DESCRIPTION
## 🛰️ Issue Number
#103 

## 🪐 작업 내용
로그인 API에서는 authorization_code를 사용하지 않도록 로직을 아래와 같이 수정하였습니다.
기존: authorization_code을 받아 서버 단에서 identityToken을 추출
변경: 클라이언트 단에서 바로 identityToken을 받음

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
