### PR TITLE
fix: 선물박스를 보낸 사람은 항상 선물박스를 열 수 있도록 수정

### DIFF
--- a/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
@@ -115,12 +115,14 @@ public class GiftBoxService {
         // 1명만 열 수 있는 선물박스이고, 이미 열린 선물박스일 경우
         if (giftBox.getGiftBoxType().equals(PRIVATE)
             && !receivers.isEmpty()
-            && !receivers.get(0).equals(receiver.getId())) {
+            && !receivers.get(0).equals(receiver.getId())
+            && !memberId.equals(giftBox.getSender().getId())) {
             throw new GiftBoxAlreadyOpenedException();
         }
 
         // 선물박스를 이전에 열지 않았던 경우
-        if (!receivers.contains(receiver.getId())) {
+        // 선물박스를 보낸 사람은 receiver에 포함하지 않음
+        if (!receivers.contains(receiver.getId()) && !giftBox.getSender().equals(receiver)) {
             receiverWriter.save(receiver, giftBox);
         }
 

--- a/packy-domain/build.gradle
+++ b/packy-domain/build.gradle
@@ -12,9 +12,9 @@ repositories {
 dependencies {
     // multi module
     implementation project(':packy-common')
-    
-    testImplementation platform('org.junit:junit-bom:5.9.1')
-    testImplementation 'org.junit.jupiter:junit-jupiter'
+
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // orm
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'


### PR DESCRIPTION
## 🛰️ Issue Number
#105 

## 🪐 작업 내용
- 선물박스 열기 API에서 receiver 엔티티 저장 로직과 이미 열린 선물박스 예외처리에서 선물박스를 보낸 사람은 고려하지 않도록 로직을 수정하였습니다. 91adf496a8498226d9c026974939657365324429
- 빌드 도중 발생한 경고 문구 `Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.`를 해결하기 위해 domain 모듈의 build.gradle을 수정하였습니다. e6fd54e895e40e5d690d3ce44c988a73c1309fc0

## 📚 Reference
- https://docs.gradle.org/8.5/userguide/upgrading_version_8.html#test_framework_implementation_dependencies

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
