### PR TITLE
fix: 요청 값 유효성 검증 추가

### DIFF
--- a/packy-api/src/main/java/com/dilly/admin/api/AdminController.java
+++ b/packy-api/src/main/java/com/dilly/admin/api/AdminController.java
@@ -90,7 +90,7 @@ public class AdminController {
     @GetMapping("/youtube")
     public DataResponseDto<StatusResponse> validateYoutubeUrl(
         @Schema(description = "유튜브 링크", type = "string")
-        @RequestParam(value = "url", required = true)
+        @RequestParam(value = "url")
         String url) {
         return DataResponseDto.from(youtubeService.validateYoutubeUrl(url));
     }

--- a/packy-api/src/main/java/com/dilly/auth/api/AuthController.java
+++ b/packy-api/src/main/java/com/dilly/auth/api/AuthController.java
@@ -14,6 +14,7 @@ import com.dilly.jwt.dto.JwtResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -43,12 +44,13 @@ public class AuthController {
         ErrorCode.APPLE_FAILED_TO_GET_PUBLIC_KEY,
         ErrorCode.APPLE_FAILED_TO_GET_INFO,
         ErrorCode.APPLE_FAILED_TO_GET_CLIENT_SECRET,
-        ErrorCode.APPLE_FAILED_TO_REVOKE_ACCOUNT
+        ErrorCode.APPLE_FAILED_TO_REVOKE_ACCOUNT,
+        ErrorCode.INVALID_INPUT_VALUE
     })
     @PostMapping("/sign-up")
     public DataResponseDto<JwtResponse> signUp(
         @RequestHeader("Authorization") @Schema(description = "Bearer prefix 제외해주세요") String providerAccessToken,
-        @RequestBody SignupRequest signupRequest) {
+        @RequestBody @Valid SignupRequest signupRequest) {
         return DataResponseDto.from(authService.signUp(providerAccessToken, signupRequest));
     }
 

--- a/packy-api/src/main/java/com/dilly/auth/api/AuthController.java
+++ b/packy-api/src/main/java/com/dilly/auth/api/AuthController.java
@@ -60,8 +60,12 @@ public class AuthController {
     })
     @GetMapping("/sign-in/{provider}")
     public DataResponseDto<SignInResponse> signIn(
-        @PathVariable(name = "provider") @Schema(description = "kakao 또는 apple") String provider,
-        @RequestHeader("Authorization") String providerAccessToken) {
+        @PathVariable(name = "provider")
+        @Schema(allowableValues = {"kakao", "apple"})
+        String provider,
+        @RequestHeader("Authorization")
+        @Schema(description = "kakao는 accessToken, apple은 identityToken을 Bearer prefix 없이 넣어주세요.")
+        String providerAccessToken) {
         return DataResponseDto.from(authService.signIn(provider, providerAccessToken));
     }
 

--- a/packy-api/src/main/java/com/dilly/auth/dto/request/SignupRequest.java
+++ b/packy-api/src/main/java/com/dilly/auth/dto/request/SignupRequest.java
@@ -4,11 +4,13 @@ import com.dilly.member.domain.Member;
 import com.dilly.member.domain.ProfileImage;
 import com.dilly.member.domain.Provider;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
 
 public record SignupRequest(
 	@Schema(example = "kakao")
 	String provider,
 	@Schema(example = "짱제이")
+	@Size(min = 2, max = 6, message = "닉네임은 2자 이상 6자 이하로 입력해주세요")
 	String nickname,
 	@Schema(example = "1")
 	Long profileImg,

--- a/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
+++ b/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -41,11 +42,12 @@ public class GiftBoxController {
     @ApiErrorCodeExamples({
         ErrorCode.BOX_NOT_FOUND,
         ErrorCode.ENVELOPE_NOT_FOUND,
-        ErrorCode.STICKER_NOT_FOUND
+        ErrorCode.STICKER_NOT_FOUND,
+        ErrorCode.INVALID_INPUT_VALUE
     })
     @PostMapping("")
     public DataResponseDto<GiftBoxIdResponse> createGiftBox(
-        @RequestBody GiftBoxRequest giftBoxRequest
+        @RequestBody @Valid GiftBoxRequest giftBoxRequest
     ) {
         return DataResponseDto.from(giftBoxService.createGiftBox(giftBoxRequest));
     }

--- a/packy-api/src/main/java/com/dilly/gift/dto/request/GiftBoxRequest.java
+++ b/packy-api/src/main/java/com/dilly/gift/dto/request/GiftBoxRequest.java
@@ -1,22 +1,27 @@
 package com.dilly.gift.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.Builder;
 
 @Builder
 public record GiftBoxRequest(
-    @Schema(example = "오늘을 위한 특별한 생일 선물")
+    @Schema(example = "너를 위해 준비했어")
+    @Size(max = 15, message = "선물박스 이름은 15자 이하로 입력해주세요.")
     String name,
-    @Schema(example = "제이(보내는 사람)")
+    @Schema(example = "보내는 사람")
+    @Size(min = 1, max = 6, message = "보내는 사람 이름은 1자 이상 6자 이하로 입력해주세요.")
     String senderName,
-    @Schema(example = "제삼(받는 사람)")
+    @Schema(example = "받는 사람")
+    @Size(min = 1, max = 6, message = "받는 사람 이름은 1자 이상 6자 이하로 입력해주세요.")
     String receiverName,
     @Schema(example = "1")
     Long boxId,
     @Schema(example = "1")
     Long envelopeId,
     @Schema(example = "생일 축하해~")
+    @Size(min = 1, max = 200, message = "편지 내용은 1자 이상 200자 이하로 입력해주세요.")
     String letterContent,
     @Schema(example = "https://www.youtube.com")
     String youtubeUrl,

--- a/packy-api/src/main/java/com/dilly/global/response/ErrorResponseDto.java
+++ b/packy-api/src/main/java/com/dilly/global/response/ErrorResponseDto.java
@@ -12,11 +12,19 @@ public class ErrorResponseDto extends ResponseDto {
 		super(errorCode.toString(), errorCode.getMessage(e));
 	}
 
+	private ErrorResponseDto(ErrorCode errorCode, String message) {
+		super(errorCode.toString(), errorCode.getMessage() + " - " + message);
+	}
+
 	public static ErrorResponseDto from(ErrorCode errorCode) {
 		return new ErrorResponseDto(errorCode);
 	}
 
 	public static ErrorResponseDto of(ErrorCode errorCode, Exception e) {
 		return new ErrorResponseDto(errorCode, e);
+	}
+
+	public static ErrorResponseDto of(ErrorCode errorCode, String message) {
+		return new ErrorResponseDto(errorCode, message);
 	}
 }

--- a/packy-api/src/main/java/com/dilly/global/response/GlobalExceptionHandler.java
+++ b/packy-api/src/main/java/com/dilly/global/response/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -43,6 +44,14 @@ public class GlobalExceptionHandler {
         return handleExceptionInternal(ErrorCode.QUERY_PARAMETER_REQUIRED);
     }
 
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<Object> handleMethodArgumentNotValidException(
+        MethodArgumentNotValidException e) {
+        log.error(e.toString(), e);
+        return handleExceptionInternal(ErrorCode.INVALID_INPUT_VALUE,
+            e.getBindingResult().getFieldErrors().get(0).getDefaultMessage());
+    }
+
     // 그 밖에 발생하는 모든 예외 처리
     @ExceptionHandler(value = {Exception.class, RuntimeException.class, SQLException.class,
         DataIntegrityViolationException.class})
@@ -60,5 +69,10 @@ public class GlobalExceptionHandler {
     private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode, Exception e) {
         return ResponseEntity.status(errorCode.getHttpStatus())
             .body(ErrorResponseDto.of(errorCode, e));
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode, String message) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+            .body(ErrorResponseDto.of(errorCode, message));
     }
 }

--- a/packy-api/src/test/java/com/dilly/gift/api/GiftBoxControllerTest.java
+++ b/packy-api/src/test/java/com/dilly/gift/api/GiftBoxControllerTest.java
@@ -57,8 +57,8 @@ class GiftBoxControllerTest extends ControllerTestSupport {
                 //given
                 GiftBoxRequest giftBoxRequest = GiftBoxRequest.builder()
                     .name("test")
-                    .senderName("sender")
-                    .receiverName("receiver")
+                    .senderName("보내는사람")
+                    .receiverName("받는사람")
                     .boxId(1L)
                     .envelopeId(1L)
                     .letterContent("This is letter content.")
@@ -90,8 +90,8 @@ class GiftBoxControllerTest extends ControllerTestSupport {
                 //given
                 GiftBoxRequest giftBoxRequest = GiftBoxRequest.builder()
                     .name("test")
-                    .senderName("sender")
-                    .receiverName("receiver")
+                    .senderName("보내는사람")
+                    .receiverName("받는사람")
                     .boxId(1L)
                     .envelopeId(1L)
                     .letterContent("This is letter content.")

--- a/packy-common/src/main/java/com/dilly/exception/ErrorCode.java
+++ b/packy-common/src/main/java/com/dilly/exception/ErrorCode.java
@@ -13,14 +13,16 @@ public enum ErrorCode {
     // Success
     OK(HttpStatus.OK, "OK"),
 
-    // Internal Server Error
     // Common
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 오류가 발생했습니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP Method 요청입니다."),
     API_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 API를 찾을 수 없습니다."),
     QUERY_PARAMETER_REQUIRED(HttpStatus.BAD_REQUEST, "쿼리 파라미터가 필요한 API입니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
+
     // Kakao
     KAKAO_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 서버 연동에 오류가 발생했습니다."),
+
     // Apple
     APPLE_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "애플 서버 연동에 오류가 발생했습니다."),
     APPLE_FAILED_TO_GET_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "애플 토큰을 가져오는데 실패했습니다."),
@@ -29,8 +31,10 @@ public enum ErrorCode {
     APPLE_FAILED_TO_GET_CLIENT_SECRET(HttpStatus.INTERNAL_SERVER_ERROR,
         "애플 client_secret을 가져오는데 실패했습니다."),
     APPLE_FAILED_TO_REVOKE_ACCOUNT(HttpStatus.INTERNAL_SERVER_ERROR, "애플 계정을 해지하는데 실패했습니다."),
+
     // Youtube
     YOUTUBE_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "유튜브 서버 연동에 오류가 발생했습니다."),
+
     // File
     FILE_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파일 서버 연동에 오류가 발생했습니다."),
 


### PR DESCRIPTION
## 🛰️ Issue Number
#109 

## 🪐 작업 내용
- 기획 요구사항에 맞춰 글자 수 제한을 추가했습니다.
  - 회원가입 시 닉네임 2자 이상 6자 이하 a23da567abb741e5a61ca367212a2f6c3740068f
  - 선물박스를 만들 때 1a110371aa756011be7051d6b4b0a2dcd0c24669
    - 선물박스 이름 공백 포함 최대 15자
    - 선물박스를 보내는 사람, 받는 사람 이름 1자 이상 6자 이하
- @Valid 어노테이션에 맞는 응답값을 전달하기 위해 MethodArgumentNotValidException 예외 핸들링을 추가했습니다. c72d11b26eb5d0ca5c016a6e9cad06605e4d8e2f
- Swagger 문서를 일부 다듬었습니다. c6d6752ece801c364e492038b847d870634d42da 79cef032ea00b75a7f7c236a19c7e195ac8ad58f

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
