### PR TITLE
fix: 주고받은 선물박스 API에 받은 사람 이름, 타입 추가

### DIFF
--- a/packy-api/src/main/java/com/dilly/gift/dto/response/GiftBoxesResponse.java
+++ b/packy-api/src/main/java/com/dilly/gift/dto/response/GiftBoxesResponse.java
@@ -3,15 +3,23 @@ package com.dilly.gift.dto.response;
 import com.dilly.gift.domain.GiftBox;
 import com.dilly.gift.domain.Receiver;
 import com.dilly.member.domain.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.Builder;
 
 @Builder
 public record GiftBoxesResponse(
+    @Schema(example = "1")
     Long id,
+    @Schema(example = "보내는사람")
     String sender,
+    @Schema(example = "받는사람")
+    String receiver,
+    @Schema(example = "최고의선물박스")
     String name,
+    @Schema(example = "2024-01-01T00:00:00")
     LocalDateTime giftBoxDate,
+    @Schema(example = "www.example.com")
     String boxNormal
 ) {
 
@@ -19,6 +27,7 @@ public record GiftBoxesResponse(
         return GiftBoxesResponse.builder()
             .id(giftBox.getId())
             .sender(giftBox.getSenderName())
+            .receiver(giftBox.getReceiverName())
             .name(giftBox.getName())
             .giftBoxDate(giftBox.getCreatedAt())
             .boxNormal(giftBox.getBox().getNormalImgUrl())
@@ -29,6 +38,7 @@ public record GiftBoxesResponse(
         return GiftBoxesResponse.builder()
             .id(receiver.getGiftBox().getId())
             .sender(receiver.getGiftBox().getSenderName())
+            .receiver(receiver.getGiftBox().getReceiverName())
             .name(receiver.getGiftBox().getName())
             .giftBoxDate(receiver.getCreatedAt())
             .boxNormal(receiver.getGiftBox().getBox().getNormalImgUrl())
@@ -46,6 +56,7 @@ public record GiftBoxesResponse(
         return GiftBoxesResponse.builder()
             .id(giftBox.getId())
             .sender(giftBox.getSenderName())
+            .receiver(giftBox.getReceiverName())
             .name(giftBox.getName())
             .giftBoxDate(giftBoxDate)
             .boxNormal(giftBox.getBox().getNormalImgUrl())

--- a/packy-api/src/main/java/com/dilly/gift/dto/response/GiftBoxesResponse.java
+++ b/packy-api/src/main/java/com/dilly/gift/dto/response/GiftBoxesResponse.java
@@ -11,6 +11,8 @@ import lombok.Builder;
 public record GiftBoxesResponse(
     @Schema(example = "1")
     Long id,
+    @Schema(example = "sent")
+    String type,
     @Schema(example = "보내는사람")
     String sender,
     @Schema(example = "받는사람")
@@ -26,6 +28,7 @@ public record GiftBoxesResponse(
     public static GiftBoxesResponse of(GiftBox giftBox) {
         return GiftBoxesResponse.builder()
             .id(giftBox.getId())
+            .type("sent")
             .sender(giftBox.getSenderName())
             .receiver(giftBox.getReceiverName())
             .name(giftBox.getName())
@@ -37,6 +40,7 @@ public record GiftBoxesResponse(
     public static GiftBoxesResponse of(Receiver receiver) {
         return GiftBoxesResponse.builder()
             .id(receiver.getGiftBox().getId())
+            .type("received")
             .sender(receiver.getGiftBox().getSenderName())
             .receiver(receiver.getGiftBox().getReceiverName())
             .name(receiver.getGiftBox().getName())
@@ -47,14 +51,18 @@ public record GiftBoxesResponse(
 
     public static GiftBoxesResponse of(GiftBox giftBox, Member member, Receiver receiver) {
         LocalDateTime giftBoxDate;
+        String type;
         if (giftBox.getSender().equals(member)) {
             giftBoxDate = giftBox.getCreatedAt();
+            type = "sent";
         } else {
             giftBoxDate = receiver.getCreatedAt();
+            type = "received";
         }
 
         return GiftBoxesResponse.builder()
             .id(giftBox.getId())
+            .type(type)
             .sender(giftBox.getSenderName())
             .receiver(giftBox.getReceiverName())
             .name(giftBox.getName())


### PR DESCRIPTION
## 🛰️ Issue Number
#114

## 🪐 작업 내용
주고받은 선물박스 API에 받은 사람 이름과 타입을 추가했습니다.

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
