### PR TITLE
deploy: logback에 Sentry DSN 환경변수 적용

### DIFF
--- a/packy-api/build.gradle
+++ b/packy-api/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     implementation 'com.github.maricn:logback-slack-appender:1.6.1'
 
     // sentry
-    implementation 'io.sentry:sentry-logback:6.26.0'
+    implementation 'io.sentry:sentry-logback:7.3.0'
 
     // apple login
     implementation 'org.bouncycastle:bcprov-jdk15on:1.69'

--- a/packy-api/src/main/resources/logback-spring.xml
+++ b/packy-api/src/main/resources/logback-spring.xml
@@ -11,6 +11,8 @@
     <springProfile name="dev">
         <property resource="application-api.yml"/>
         <springProperty name="SLACK_WEBHOOK_URL" source="logging.slack.webhook-url.dev"/>
+        <springProperty name="SENTRY_DSN_DEV" source="logging.sentry.dsn.dev"/>
+
         <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
             <webhookUri>${SLACK_WEBHOOK_URL}</webhookUri>
             <channel>패키-서버-에러-dev</channel>
@@ -35,8 +37,6 @@
         </appender>
 
         <appender name="Sentry" class="io.sentry.logback.SentryAppender">
-            <property resource="application-api.yml"/>
-            <springProperty name="SENTRY_DSN_DEV" source="logging.sentry.dsn.dev"/>
             <options>
                 <dsn>${SENTRY_DSN_DEV}</dsn>
             </options>
@@ -57,6 +57,8 @@
     <springProfile name="prod">
         <property resource="application-api.yml"/>
         <springProperty name="SLACK_WEBHOOK_URL_PROD" source="logging.slack.webhook-url.prod"/>
+        <springProperty name="SENTRY_DSN_PROD" source="logging.sentry.dsn.prod"/>
+
         <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
             <webhookUri>${SLACK_WEBHOOK_URL_PROD}</webhookUri>
             <channel>패키-서버-에러-dev</channel>
@@ -81,8 +83,6 @@
         </appender>
 
         <appender name="Sentry" class="io.sentry.logback.SentryAppender">
-            <property resource="application-api.yml"/>
-            <springProperty name="SENTRY_DSN_PROD" source="logging.sentry.dsn.prod"/>
             <options>
                 <dsn>${SENTRY_DSN_PROD}</dsn>
             </options>


### PR DESCRIPTION
## 🛰️ Issue Number
#21 

## 🪐 작업 내용
- logback-spring.xml에서 Sentry DSN 환경변수를 작성하는 위치가 잘못되어서 수정하였습니다.

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
