### PR TITLE
fix: 스티커 조회가 sequence 순으로 페이징되도록 수정

### DIFF
--- a/packy-api/src/main/java/com/dilly/admin/api/AdminController.java
+++ b/packy-api/src/main/java/com/dilly/admin/api/AdminController.java
@@ -67,7 +67,6 @@ public class AdminController {
         return DataResponseDto.from(adminService.getMusics());
     }
 
-    // TODO: sequence 순으로 페이징
     @Operation(summary = "스티커 조회")
     @Parameter(in = ParameterIn.QUERY
         , description = "한 페이지에 보여줄 스티커 개수. 기본값은 10개"

--- a/packy-api/src/main/java/com/dilly/admin/application/AdminService.java
+++ b/packy-api/src/main/java/com/dilly/admin/application/AdminService.java
@@ -64,7 +64,11 @@ public class AdminService {
     }
 
     public Slice<ImgResponse> getStickers(Long lastStickerId, Pageable pageable) {
-        Slice<Sticker> stickerSlice = stickerReader.searchBySlice(lastStickerId, pageable);
+        Long lastSequence = 0L;
+        if (lastStickerId != null) {
+            lastSequence = stickerReader.findById(lastStickerId).getSequence();
+        }
+        Slice<Sticker> stickerSlice = stickerReader.searchBySlice(lastSequence, pageable);
         List<ImgResponse> imgResponses = stickerSlice.getContent().stream()
             .map(ImgResponse::from)
             .toList();

--- a/packy-domain/src/main/java/com/dilly/gift/adaptor/StickerReader.java
+++ b/packy-domain/src/main/java/com/dilly/gift/adaptor/StickerReader.java
@@ -17,8 +17,8 @@ public class StickerReader {
     private final StickerRepository stickerRepository;
     private final StickerQueryRepository stickerQueryRepository;
 
-    public Slice<Sticker> searchBySlice(Long lastStickerId, Pageable pageable) {
-        return stickerQueryRepository.searchBySlice(lastStickerId, pageable);
+    public Slice<Sticker> searchBySlice(Long lastSequence, Pageable pageable) {
+        return stickerQueryRepository.searchBySlice(lastSequence, pageable);
     }
 
     public Sticker findById(Long id) {

--- a/packy-domain/src/main/java/com/dilly/gift/dao/querydsl/StickerQueryRepository.java
+++ b/packy-domain/src/main/java/com/dilly/gift/dao/querydsl/StickerQueryRepository.java
@@ -18,9 +18,9 @@ public class StickerQueryRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
-    public Slice<Sticker> searchBySlice(Long lastStickerId, Pageable pageable) {
+    public Slice<Sticker> searchBySlice(Long lastSequence, Pageable pageable) {
         List<Sticker> results = jpaQueryFactory.selectFrom(sticker)
-            .where(gtStickerId(lastStickerId))
+            .where(gtSequence(lastSequence))
             .orderBy(sticker.sequence.asc())
             .limit(pageable.getPageSize() + 1L)
             .fetch();
@@ -29,12 +29,12 @@ public class StickerQueryRepository {
     }
 
     // No-offset
-    private BooleanExpression gtStickerId(Long stickerId) {
-        if (stickerId == null) {
+    private BooleanExpression gtSequence(Long sequence) {
+        if (sequence == null) {
             return null;
         }
 
-        return sticker.id.gt(stickerId);
+        return sticker.sequence.gt(sequence);
     }
 
     // 무한 스크롤


### PR DESCRIPTION
## 🛰️ Issue Number
#110 

## 🪐 작업 내용
id순으로 페이징이 되던 스티커 조회 API를 sequence순으로 페이징이 되도록 수정하였습니다.

아직까지는 순서가 크게 중요하지 않아 id와 sequence가 동일한데, id순으로 페이징하게 된다면 PK는 앞 번호이지만 sequence가 끝 번호인 상황에서 페이징이 정상적으로 동작하지 않을 수 있습니다.

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
