### PR TITLE
fix: Github Actions 잘못된 Indent 수정

### DIFF
--- a/.github/workflows/packy-cd-prod.yml
+++ b/.github/workflows/packy-cd-prod.yml
@@ -70,5 +70,5 @@ jobs:
         uses: release-drafter/release-drafter@v5
         with:
           config-name: release-drafter-config.yml
-          env:
-            GITHUB_TOKEN: ${{ secrets.ACTION_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTION_TOKEN }}


### PR DESCRIPTION
## 🛰️ Issue Number
#138 

## 🪐 작업 내용
- Release Drafter 액션에서 Indent가 잘못되어 액션이 돌지 않는 문제를 해결했습니다.

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
