### PR TITLE
setting: jacoco 연동 및 CI workflow에서 커버리지 확인

### DIFF
--- a/.github/workflows/packy-ci.yml
+++ b/.github/workflows/packy-ci.yml
@@ -29,3 +29,9 @@ jobs:
 
       - name: Run build with Gradle Wrapper
         run: ./gradlew clean build --parallel
+
+      - name: Report to CodeCov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: 'packy-support/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml'

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,16 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.1'
     id 'io.spring.dependency-management' version '1.1.4'
+    id 'jacoco'
 }
 
 java {
     sourceCompatibility = '17'
+}
+
+jacoco {
+    toolVersion = '0.8.11'
+
 }
 
 // 루트 프로젝트를 포함해 하위 프로젝트 전체에 영향을 주는 설정
@@ -28,6 +34,7 @@ subprojects {
     apply plugin: 'java-library'
     apply plugin: 'org.springframework.boot'
     apply plugin: 'io.spring.dependency-management'
+    apply plugin: 'jacoco'
 
     dependencies {
         // basic

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/packy-support/build.gradle
+++ b/packy-support/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+    id 'java'
+    id 'jacoco-report-aggregation'
+}
+
+group = 'com.dilly'
+version = '0.0.1-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    jacocoAggregation project(':packy-api')
+    jacocoAggregation project(':packy-domain')
+}
+
+test {
+    useJUnitPlatform()
+}
+
+bootJar.enabled = false
+jar.enabled = true

--- a/packy-support/build.gradle
+++ b/packy-support/build.gradle
@@ -25,12 +25,17 @@ testCodeCoverageReport {
         html.required = true
     }
 
+    def Qdomains = []
+    for (qPattern in '**/QA'..'**/QZ') {
+        Qdomains.add(qPattern + '*')
+    }
+
     afterEvaluate {
         classDirectories.setFrom(
                 files(classDirectories.files.collect {
                     fileTree(dir: it, excludes: [
                             'com/dilly/exception/**'
-                    ])
+                    ] + Qdomains)
                 })
         )
     }

--- a/packy-support/build.gradle
+++ b/packy-support/build.gradle
@@ -25,6 +25,15 @@ testCodeCoverageReport {
         html.required = true
     }
 
+    afterEvaluate {
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, excludes: [
+                            'com/dilly/exception/**'
+                    ])
+                })
+        )
+    }
 }
 
 bootJar.enabled = false

--- a/packy-support/build.gradle
+++ b/packy-support/build.gradle
@@ -23,6 +23,7 @@ test {
 testCodeCoverageReport {
     reports {
         html.required = true
+        xml.required = true
     }
 
     def Qdomains = []

--- a/packy-support/build.gradle
+++ b/packy-support/build.gradle
@@ -17,6 +17,14 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    finalizedBy 'testCodeCoverageReport'
+}
+
+testCodeCoverageReport {
+    reports {
+        html.required = true
+    }
+
 }
 
 bootJar.enabled = false

--- a/packy-support/build.gradle
+++ b/packy-support/build.gradle
@@ -34,7 +34,10 @@ testCodeCoverageReport {
         classDirectories.setFrom(
                 files(classDirectories.files.collect {
                     fileTree(dir: it, excludes: [
-                            'com/dilly/exception/**'
+                            'com/dilly/exception/**',
+                            'com/dilly/**/config/**',
+                            'com/dilly/**/dto/**',
+                            'com/dilly/**/model/**'
                     ] + Qdomains)
                 })
         )

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,5 @@ include 'packy-api'
 include 'packy-domain'
 include 'packy-infra'
 include 'packy-common'
+include 'packy-support'
 


### PR DESCRIPTION
## 🛰️ Issue Number
#131 

## 🪐 작업 내용
- jacoco 플러그인을 연동하였습니다.
- jacoco-report-aggregation을 사용하여 여러 모듈에 흩어진 리포트를 support 모듈에 통합하였습니다.
- lombok으로 생성된 메서드, Exception 클래스, Q클래스, Config 클래스, DTO 클래스, Model 클래스를 테스트 커버리지 분석 대상에서 제외하였습니다.
- Codecov를 연동하여 CI workflow 동작 시 PR Comment로 커버리지 분석 리포트를 제공하도록 하였습니다.

## 📚 Reference

- https://bottom-to-top.tistory.com/36
- https://jane514.tistory.com/12
- https://cl8d.tistory.com/119

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [ ] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
