### PR TITLE
fix: 글자 수 유효성 검증을 커스텀 어노테이션을 사용하도록 변경

### DIFF
--- a/.github/workflows/packy-cd-dev.yml
+++ b/.github/workflows/packy-cd-dev.yml
@@ -51,6 +51,7 @@ jobs:
         run: |
           mkdir -p deploy/.platform/nginx/conf.d
           cp Dockerrun.aws.dev.json deploy/Dockerrun.aws.json
+          cp -r .ebextensions deploy/.ebextensions
           cp .platform/nginx/conf.d/proxy-dev.conf deploy/.platform/nginx/conf.d/proxy.conf
           cd deploy && zip -r deploy.zip .
 

--- a/.github/workflows/packy-cd-prod.yml
+++ b/.github/workflows/packy-cd-prod.yml
@@ -51,6 +51,7 @@ jobs:
         run: |
           mkdir -p deploy/.platform/nginx/conf.d
           cp Dockerrun.aws.prod.json deploy/Dockerrun.aws.json
+          cp -r .ebextensions deploy/.ebextensions
           cp .platform/nginx/conf.d/proxy-prod.conf deploy/.platform/nginx/conf.d/proxy.conf
           cd deploy && zip -r deploy.zip .
 

--- a/packy-api/src/main/java/com/dilly/auth/dto/request/SignupRequest.java
+++ b/packy-api/src/main/java/com/dilly/auth/dto/request/SignupRequest.java
@@ -1,16 +1,16 @@
 package com.dilly.auth.dto.request;
 
+import com.dilly.global.utils.validator.CustomSize;
 import com.dilly.member.domain.Member;
 import com.dilly.member.domain.ProfileImage;
 import com.dilly.member.domain.Provider;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Size;
 
 public record SignupRequest(
 	@Schema(example = "kakao")
 	String provider,
 	@Schema(example = "짱제이")
-	@Size(min = 2, max = 6, message = "닉네임은 2자 이상 6자 이하로 입력해주세요")
+	@CustomSize(min = 2, max = 6, message = "닉네임은 2자 이상 6자 이하로 입력해주세요")
 	String nickname,
 	@Schema(example = "1")
 	Long profileImg,

--- a/packy-api/src/main/java/com/dilly/gift/dto/request/GiftBoxRequest.java
+++ b/packy-api/src/main/java/com/dilly/gift/dto/request/GiftBoxRequest.java
@@ -2,20 +2,19 @@ package com.dilly.gift.dto.request;
 
 import com.dilly.global.utils.validator.CustomSize;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.Builder;
 
 @Builder
 public record GiftBoxRequest(
     @Schema(example = "너를 위해 준비했어")
-    @Size(max = 15, message = "선물박스 이름은 15자 이하로 입력해주세요.")
+    @CustomSize(max = 15, message = "선물박스 이름은 15자 이하로 입력해주세요.")
     String name,
     @Schema(example = "보내는 사람")
-    @Size(min = 1, max = 6, message = "보내는 사람 이름은 1자 이상 6자 이하로 입력해주세요.")
+    @CustomSize(min = 1, max = 6, message = "보내는 사람 이름은 1자 이상 6자 이하로 입력해주세요.")
     String senderName,
     @Schema(example = "받는 사람")
-    @Size(min = 1, max = 6, message = "받는 사람 이름은 1자 이상 6자 이하로 입력해주세요.")
+    @CustomSize(min = 1, max = 6, message = "받는 사람 이름은 1자 이상 6자 이하로 입력해주세요.")
     String receiverName,
     @Schema(example = "1")
     Long boxId,

--- a/packy-api/src/main/java/com/dilly/gift/dto/request/PhotoRequest.java
+++ b/packy-api/src/main/java/com/dilly/gift/dto/request/PhotoRequest.java
@@ -1,5 +1,6 @@
 package com.dilly.gift.dto.request;
 
+import com.dilly.global.utils.validator.CustomSize;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -8,6 +9,7 @@ public record PhotoRequest(
 	@Schema(example = "www.test.com")
 	String photoUrl,
 	@Schema(example = "우리 같이 놀러갔던 날 :)")
+	@CustomSize(max = 20, message = "사진 속 추억은 20자 이하로 입력해주세요.")
 	String description,
 	@Schema(example = "1")
 	Integer sequence


### PR DESCRIPTION
## 🛰️ Issue Number
#162 #73

## 🪐 작업 내용
- 글자 수 유효성 검증을 커스텀 어노테이션(이모지를 1글자로 계산)으로 진행하도록 코드를 수정하였습니다. e9389c1d10364e850c1ad59629cf802f680d2821
- Github Actions에서 deploy 패키지를 만들 때 ebextensions를 추가하도록 워크플로우를 수정하였습니다. ad96af1c334deca838259decffa6af635ae99b8f

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
