### PR TITLE
fix: 선물 모아보기 API에서 gift가 null인 선물박스를 제외

### DIFF
--- a/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
@@ -141,7 +141,7 @@ public class GiftBoxService {
 
         GiftResponse giftResponse = null;
         if (giftBox.getGift() != null) {
-            giftResponse = GiftResponse.of(giftBox.getGift());
+            giftResponse = GiftResponse.from(giftBox.getGift());
         }
 
         return GiftBoxResponse.of(giftBox, boxResponse, envelopeResponse, photos, stickers,

--- a/packy-api/src/main/java/com/dilly/gift/application/GiftService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftService.java
@@ -111,7 +111,7 @@ public class GiftService {
 
             lastGiftBoxDate = lastReceiver.getCreatedAt();
         }
-        Slice<GiftBox> giftBoxSlice = giftBoxReader.searchReceivedGiftBoxesBySlice(member,
+        Slice<GiftBox> giftBoxSlice = giftBoxReader.searchReceivedGiftBoxesWithGiftBySlice(member,
             lastGiftBoxDate, pageable);
 
         List<ItemResponse> itemResponses = giftBoxSlice.stream()

--- a/packy-api/src/main/java/com/dilly/gift/dto/response/GiftResponseDto.java
+++ b/packy-api/src/main/java/com/dilly/gift/dto/response/GiftResponseDto.java
@@ -15,7 +15,7 @@ public class GiftResponseDto {
         String url
     ) {
 
-        public static GiftResponse of(Gift gift) {
+        public static GiftResponse from(Gift gift) {
             return GiftResponse.builder()
                 .type(String.valueOf(gift.getGiftType()).toLowerCase())
                 .url(gift.getGiftUrl())
@@ -33,7 +33,7 @@ public class GiftResponseDto {
             public static ItemResponse from(GiftBox giftBox) {
                 return ItemResponse.builder()
                     .giftBoxId(giftBox.getId())
-                    .gift(GiftResponse.of(giftBox.getGift()))
+                    .gift(GiftResponse.from(giftBox.getGift()))
                     .build();
             }
     }

--- a/packy-api/src/test/java/com/dilly/gift/application/GiftBoxServiceTest.java
+++ b/packy-api/src/test/java/com/dilly/gift/application/GiftBoxServiceTest.java
@@ -177,7 +177,7 @@ class GiftBoxServiceTest extends IntegrationTestSupport {
                     .map(StickerResponse::of)
                     .sorted(Comparator.comparingInt(StickerResponse::location))
                     .toList();
-                GiftResponse expectedGiftResponse = GiftResponse.of(giftBoxWithGift.getGift());
+                GiftResponse expectedGiftResponse = GiftResponse.from(giftBoxWithGift.getGift());
 
                 // when
                 GiftBoxResponse giftBoxResponse = giftBoxService.openGiftBox(
@@ -270,7 +270,7 @@ class GiftBoxServiceTest extends IntegrationTestSupport {
                     .map(StickerResponse::of)
                     .sorted(Comparator.comparingInt(StickerResponse::location))
                     .toList();
-                GiftResponse expectedGiftResponse = GiftResponse.of(giftBox.getGift());
+                GiftResponse expectedGiftResponse = GiftResponse.from(giftBox.getGift());
 
                 // when
                 GiftBoxResponse giftBoxResponse = giftBoxService.openGiftBox(giftBox.getId());

--- a/packy-domain/src/main/java/com/dilly/gift/adaptor/GiftBoxReader.java
+++ b/packy-domain/src/main/java/com/dilly/gift/adaptor/GiftBoxReader.java
@@ -47,4 +47,10 @@ public class GiftBoxReader {
         return giftBoxQueryRepository.searchAllGiftBoxesBySlice(member, lastGiftBoxDate, comparator,
             pageable);
     }
+
+    public Slice<GiftBox> searchReceivedGiftBoxesWithGiftBySlice(Member member,
+        LocalDateTime lastGiftBoxDate, Pageable pageable) {
+        return giftBoxQueryRepository.searchReceivedGiftBoxesWithGiftBySlice(member,
+            lastGiftBoxDate, pageable);
+    }
 }

--- a/packy-domain/src/main/java/com/dilly/gift/dao/querydsl/GiftBoxQueryRepository.java
+++ b/packy-domain/src/main/java/com/dilly/gift/dao/querydsl/GiftBoxQueryRepository.java
@@ -53,6 +53,24 @@ public class GiftBoxQueryRepository {
         return checkLastPage(pageable, results);
     }
 
+    public Slice<GiftBox> searchReceivedGiftBoxesWithGiftBySlice(Member member,
+        LocalDateTime lastGiftBoxDate,
+        Pageable pageable) {
+        List<GiftBox> results = jpaQueryFactory.select(giftBox)
+            .from(receiver)
+            .join(receiver.giftBox, giftBox)
+            .where(
+                ltReceivedDate(lastGiftBoxDate),
+                receiver.member.eq(member),
+                giftBox.gift.isNotNull()
+            )
+            .orderBy(receiver.createdAt.desc())
+            .limit(pageable.getPageSize() + 1L)
+            .fetch();
+
+        return checkLastPage(pageable, results);
+    }
+
     private List<GiftBox> getSentGiftBoxes(Member member, LocalDateTime lastGiftBoxDate,
         Pageable pageable) {
         return jpaQueryFactory.selectFrom(giftBox)


### PR DESCRIPTION
## 🛰️ Issue Number
#164 

## 🪐 작업 내용
받은 선물박스 API에서 사용하는 searchSentGiftBoxesBySlice 메서드를 재활용하여 선물이 없을 경우(= gift가 null일 경우) 엔티티를 DTO로 변환하는 메서드에서 NPE가 발생했습니다.

gift가 null이 아닌 조건을 추가한 searchReceivedGiftBoxesWithGiftBySlice를 새로 만들어 사용하도록 코드를 수정하였습니다. 4706035695cd53374245daf332e47cbe885768c4
### 부가 작업
- GiftResponse에서 엔티티를 DTO로 변환하는 정적 팩토리 메서드의 이름을 매개변수 개수에 따른 명명법에 따라 from으로 변경하였습니다. 24cc8bfeba504a9c54c056c659a573afc88df364

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [ ] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
