### PR TITLE
fix: 로그인 API 응답값에 닉네임 추가

### DIFF
--- a/packy-api/src/main/java/com/dilly/auth/application/AuthService.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/AuthService.java
@@ -116,15 +116,12 @@ public class AuthService {
 
 		SignInResponse signInResponse;
 		if (member.isEmpty()) {
-			signInResponse = SignInResponse.builder()
-				.status(Status.NOT_REGISTERED)
-				.tokenInfo(JwtResponse.builder().build())
-				.build();
+			signInResponse = SignInResponse.from(Status.NOT_REGISTERED,
+				JwtResponse.builder().build());
 		} else {
-			signInResponse = SignInResponse.builder()
-				.status(member.get().getStatus())
-				.tokenInfo(jwtService.issueJwt(member.get()))
-				.build();
+			signInResponse = SignInResponse.from(member.get().getStatus(),
+				member.get().getNickname(),
+				jwtService.issueJwt(member.get()));
 		}
 
 		return signInResponse;

--- a/packy-api/src/main/java/com/dilly/auth/dto/response/SignInResponse.java
+++ b/packy-api/src/main/java/com/dilly/auth/dto/response/SignInResponse.java
@@ -2,11 +2,32 @@ package com.dilly.auth.dto.response;
 
 import com.dilly.jwt.dto.JwtResponse;
 import com.dilly.member.domain.Status;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record SignInResponse(
+	@Schema(example = "NOT_REGISTERED")
 	Status status,
+	@Schema(example = "짱제이")
+	String nickname,
 	JwtResponse tokenInfo
 ) {
+
+	public static SignInResponse from(Status status, JwtResponse tokenInfo) {
+		return SignInResponse.builder()
+			.status(status)
+			.tokenInfo(tokenInfo)
+			.build();
+	}
+
+	public static SignInResponse from(Status status, String nickname, JwtResponse tokenInfo) {
+		return SignInResponse.builder()
+			.status(status)
+			.nickname(nickname)
+			.tokenInfo(tokenInfo)
+			.build();
+	}
 }


### PR DESCRIPTION
## 🛰️ Issue Number
#144 

## 🪐 작업 내용
클라이언트의 요청 사항에 따라 로그인 API 응답값에 닉네임을 추가하였습니다.
`@JsonInclude(JsonInclude.Include.NON_NULL)`을 적용하여 회원가입한 유저일 경우에만 닉네임 컬럼이 반환됩니다.

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
