### PR TITLE
feat: 선물박스 삭제 API 구현

### DIFF
--- a/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
+++ b/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
@@ -19,6 +19,7 @@ import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -88,5 +89,17 @@ public class GiftBoxController {
         return DataResponseDto.from(
             SliceResponseDto.from(giftBoxService.getGiftBoxes(lastGiftBoxDate, type, pageable))
         );
+    }
+
+    @Operation(summary = "선물박스 삭제")
+    @ApiErrorCodeExamples({
+        ErrorCode.GIFTBOX_NOT_FOUND,
+        ErrorCode.GIFTBOX_ACCESS_DENIED
+    })
+    @DeleteMapping("/{giftBoxId}")
+    public DataResponseDto<String> deleteGiftBox(
+        @PathVariable("giftBoxId") Long giftBoxId
+    ) {
+        return DataResponseDto.from(giftBoxService.deleteGiftBox(giftBoxId));
     }
 }

--- a/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
@@ -117,6 +117,7 @@ public class GiftBoxService {
 
             if (receivers.isEmpty() && giftBox.getSenderDeleted().equals(false)) {
                 receiverWriter.save(member, giftBox);
+                return;
             }
 
             if (receivers.contains(member.getId())) {

--- a/packy-common/src/main/java/com/dilly/exception/ErrorCode.java
+++ b/packy-common/src/main/java/com/dilly/exception/ErrorCode.java
@@ -65,6 +65,7 @@ public enum ErrorCode {
     BOX_NOT_FOUND(HttpStatus.NOT_FOUND, "선물 박스를 찾을 수 없습니다."),
     ENVELOPE_NOT_FOUND(HttpStatus.NOT_FOUND, "편지 봉투를 찾을 수 없습니다."),
     GIFTBOX_ALREADY_OPENDED(HttpStatus.CONFLICT, "이미 열린 선물입니다."),
+    GIFTBOX_ACCESS_DENIED(HttpStatus.FORBIDDEN, "선물박스에 접근할 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/packy-common/src/main/java/com/dilly/exception/GiftBoxAccessDeniedException.java
+++ b/packy-common/src/main/java/com/dilly/exception/GiftBoxAccessDeniedException.java
@@ -1,0 +1,9 @@
+package com.dilly.exception;
+
+public class GiftBoxAccessDeniedException extends BusinessException {
+
+    public GiftBoxAccessDeniedException() {
+        super(ErrorCode.GIFTBOX_ACCESS_DENIED);
+    }
+
+}

--- a/packy-domain/src/main/java/com/dilly/gift/dao/querydsl/GiftBoxQueryRepository.java
+++ b/packy-domain/src/main/java/com/dilly/gift/dao/querydsl/GiftBoxQueryRepository.java
@@ -4,6 +4,7 @@ import static com.dilly.gift.domain.QGiftBox.giftBox;
 import static com.dilly.gift.domain.QReceiver.receiver;
 
 import com.dilly.gift.domain.GiftBox;
+import com.dilly.gift.domain.ReceiverStatus;
 import com.dilly.member.domain.Member;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -62,6 +63,7 @@ public class GiftBoxQueryRepository {
             .where(
                 ltReceivedDate(lastGiftBoxDate),
                 receiver.member.eq(member),
+                receiver.status.eq(ReceiverStatus.RECEIVED),
                 giftBox.gift.isNotNull()
             )
             .orderBy(receiver.createdAt.desc())
@@ -76,7 +78,8 @@ public class GiftBoxQueryRepository {
         return jpaQueryFactory.selectFrom(giftBox)
             .where(
                 ltGiftBoxDate(lastGiftBoxDate),
-                giftBox.sender.eq(member))
+                giftBox.sender.eq(member),
+                giftBox.senderDeleted.eq(false))
             .orderBy(giftBox.createdAt.desc())
             .limit(pageable.getPageSize() + 1L)
             .fetch();
@@ -89,7 +92,8 @@ public class GiftBoxQueryRepository {
             .join(receiver.giftBox, giftBox)
             .where(
                 ltReceivedDate(lastGiftBoxDate),
-                receiver.member.eq(member))
+                receiver.member.eq(member),
+                receiver.status.eq(ReceiverStatus.RECEIVED))
             .orderBy(receiver.createdAt.desc())
             .limit(pageable.getPageSize() + 1L)
             .fetch();

--- a/packy-domain/src/main/java/com/dilly/gift/dao/querydsl/LetterQueryRepository.java
+++ b/packy-domain/src/main/java/com/dilly/gift/dao/querydsl/LetterQueryRepository.java
@@ -5,6 +5,7 @@ import static com.dilly.gift.domain.QLetter.letter;
 import static com.dilly.gift.domain.QReceiver.receiver;
 
 import com.dilly.gift.domain.Letter;
+import com.dilly.gift.domain.ReceiverStatus;
 import com.dilly.member.domain.Member;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -29,7 +30,8 @@ public class LetterQueryRepository {
             .join(giftBox.letter, letter)
             .where(
                 ltLetterDate(lastLetterDate),
-                receiver.member.eq(member)
+                receiver.member.eq(member),
+                receiver.status.eq(ReceiverStatus.RECEIVED)
             )
             .orderBy(receiver.createdAt.desc())
             .limit(pageable.getPageSize() + 1L)

--- a/packy-domain/src/main/java/com/dilly/gift/dao/querydsl/PhotoQueryRepository.java
+++ b/packy-domain/src/main/java/com/dilly/gift/dao/querydsl/PhotoQueryRepository.java
@@ -5,6 +5,7 @@ import static com.dilly.gift.domain.QPhoto.photo;
 import static com.dilly.gift.domain.QReceiver.receiver;
 
 import com.dilly.gift.domain.Photo;
+import com.dilly.gift.domain.ReceiverStatus;
 import com.dilly.member.domain.Member;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -30,7 +31,8 @@ public class PhotoQueryRepository {
             .join(receiver.giftBox.photos, photo)
             .where(
                 ltPhotoDate(lastPhotoDate),
-                receiver.member.eq(member)
+                receiver.member.eq(member),
+                receiver.status.eq(ReceiverStatus.RECEIVED)
             )
             .orderBy(receiver.createdAt.desc())
             .limit(pageable.getPageSize() + 1L)

--- a/packy-domain/src/main/java/com/dilly/gift/domain/GiftBox.java
+++ b/packy-domain/src/main/java/com/dilly/gift/domain/GiftBox.java
@@ -66,4 +66,11 @@ public class GiftBox extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Builder.Default
     private GiftBoxType giftBoxType = GiftBoxType.PRIVATE;
+
+    @Builder.Default
+    private Boolean senderDeleted = false;
+
+    public void delete() {
+        this.senderDeleted = true;
+    }
 }

--- a/packy-domain/src/main/java/com/dilly/gift/domain/GiftBoxRole.java
+++ b/packy-domain/src/main/java/com/dilly/gift/domain/GiftBoxRole.java
@@ -1,0 +1,6 @@
+package com.dilly.gift.domain;
+
+public enum GiftBoxRole {
+    SENDER,
+    RECEIVER
+}

--- a/packy-domain/src/main/java/com/dilly/gift/domain/Receiver.java
+++ b/packy-domain/src/main/java/com/dilly/gift/domain/Receiver.java
@@ -4,7 +4,10 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 
 import com.dilly.global.BaseTimeEntity;
 import com.dilly.member.domain.Member;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -33,10 +36,19 @@ public class Receiver extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private GiftBox giftBox;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status")
+    @Builder.Default
+    private ReceiverStatus status = ReceiverStatus.RECEIVED;
+
     public static Receiver of(Member member, GiftBox giftBox) {
         return Receiver.builder()
             .member(member)
             .giftBox(giftBox)
             .build();
+    }
+
+    public void delete() {
+        this.status = ReceiverStatus.DELETED;
     }
 }

--- a/packy-domain/src/main/java/com/dilly/gift/domain/ReceiverStatus.java
+++ b/packy-domain/src/main/java/com/dilly/gift/domain/ReceiverStatus.java
@@ -1,0 +1,6 @@
+package com.dilly.gift.domain;
+
+public enum ReceiverStatus {
+    RECEIVED,
+    DELETED
+}

--- a/packy-domain/src/main/resources/db/migration/V29__add_delete_status_in_gift_box_and_receiver_table.sql
+++ b/packy-domain/src/main/resources/db/migration/V29__add_delete_status_in_gift_box_and_receiver_table.sql
@@ -1,0 +1,8 @@
+-- gift_box 테이블에 sender_deleted 컬럼 추가
+alter table gift_box
+add column sender_deleted bit not null default false;
+
+-- receiver 테이블에 status 컬럼 추가
+alter table receiver
+add column status enum('RECEIVED', 'DELETED') not null default 'RECEIVED';
+´


### PR DESCRIPTION
## 🛰️ Issue Number
#170 

## 🪐 작업 내용
- 선물박스 삭제 API를 soft delete 방식으로 구현했습니다.
  - 선물박스를 삭제할 경우 삭제하지 않은 상대방은 계속 조회를 할 수 있으며 삭제한 유저에게 보이지 않도록 구현해야 합니다.
  - 선물박스를 보낸 사람이 삭제했는지 여부는 `GiftBox 엔티티의 senderDeleted`, 받은 사람이 삭제했는지 여부는 `Receiver 엔티티의 status`로 구현했습니다.

- 삭제한 선물박스는 조회 시 포함되지 않도록 쿼리 조건을 추가하였습니다.
  - 보낸 선물박스를 조회: senderDeleted=true 조건 추가
  - 받은 선물박스를 조회: receiverStatus = 'RECEIVED' 조건 추가
  - 선물박스 열기 API에서는 아래와 같은 상황일 때 `GiftBoxAccessDeniedException`를 반환합니다.
    - 선물박스를 보낸 사람이며, senderDeleted=true일 경우
    - 선물박스를 이미 받은 사람이며, receiverStatus = 'DELETED'일 경우 
  - 모아보기 API: receiverStatus = 'RECEIVED' 조건 추가

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
