### PR TITLE
deploy: flyway 스크립트 오타 수정

### DIFF
--- a/packy-domain/src/main/resources/db/migration/V29__add_delete_status_in_gift_box_and_receiver_table.sql
+++ b/packy-domain/src/main/resources/db/migration/V29__add_delete_status_in_gift_box_and_receiver_table.sql
@@ -5,4 +5,4 @@ add column sender_deleted bit not null default false;
 -- receiver 테이블에 status 컬럼 추가
 alter table receiver
 add column status enum('RECEIVED', 'DELETED') not null default 'RECEIVED';
-´
+


### PR DESCRIPTION
## 🛰️ Issue Number
X

## 🪐 작업 내용
어이가 업네요 ,,, 
V29__add_delete_status_in_gift_box_and_receiver_table.sql 마지막에 `´`가 추가되어 스프링부트 애플리케이션 실행이 안됐었습니다 ... ^^

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
