### PR TITLE
feat: 보내지 않은 선물박스 조회 API 구현

### DIFF
--- a/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
+++ b/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
@@ -7,6 +7,7 @@ import com.dilly.gift.dto.request.GiftBoxRequest;
 import com.dilly.gift.dto.response.GiftBoxIdResponse;
 import com.dilly.gift.dto.response.GiftBoxResponse;
 import com.dilly.gift.dto.response.GiftBoxesResponse;
+import com.dilly.gift.dto.response.WaitingGiftBoxResponse;
 import com.dilly.global.response.DataResponseDto;
 import com.dilly.global.response.SliceResponseDto;
 import com.dilly.global.swagger.ApiErrorCodeExamples;
@@ -17,6 +18,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -122,5 +124,11 @@ public class GiftBoxController {
     ) {
         return DataResponseDto.from(
             giftBoxService.updateDeliverStatus(giftBoxId, deliverStatusRequest));
+    }
+
+    @Operation(summary = "보내지 않은 선물박스 조회", description = "최신순으로 6개를 조회합니다.")
+    @GetMapping("/waiting")
+    public DataResponseDto<List<WaitingGiftBoxResponse>> getWaitingGiftBoxes() {
+        return DataResponseDto.from(giftBoxService.getWaitingGiftBoxes());
     }
 }

--- a/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
+++ b/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
@@ -39,8 +39,8 @@ public class GiftBoxController {
     private final GiftBoxService giftBoxService;
 
     @Operation(summary = "선물박스 만들기", description = """
-        1. giftType은 photo만 가능합니다.
-        2. gift가 없을 경우 null로 보내주세요.
+        giftType은 photo만 가능합니다. <br>
+        gift가 없을 경우 null로 보내주세요. <br>
         """)
     @ApiErrorCodeExamples({
         ErrorCode.BOX_NOT_FOUND,
@@ -56,8 +56,8 @@ public class GiftBoxController {
     }
 
     @Operation(summary = "선물박스 열기", description = """
-        1. 선물이 없을 경우 응답에서 gift 객체가 제외됩니다.
-        2. 이미 열린 선물박스는 다른 사람이 열 수 없습니다.
+        선물이 없을 경우 응답에서 gift 객체가 제외됩니다. <br>
+        이미 열린 선물박스는 다른 사람이 열 수 없습니다. <br>
         """)
     @ApiErrorCodeExamples({
         ErrorCode.GIFTBOX_NOT_FOUND,
@@ -107,9 +107,9 @@ public class GiftBoxController {
     }
 
     @Operation(summary = "선물박스 전송 상태 변경", description = """
-        STATUS는 WAITING, DELIVERED 두 가지입니다.
-        선물박스 만들기 API를 호출하면 WAITING 상태로 만들어집니다.
-        카카오톡으로 보내기 버튼을 누를 때 해당 API를 호출하여 전송 상태를 DELIVERED로 변경합니다.
+        STATUS는 WAITING, DELIVERED 두 가지입니다. <br>
+        선물박스 만들기 API를 호출하면 WAITING 상태로 만들어집니다. <br>
+        카카오톡으로 보내기 버튼을 누를 때 해당 API를 호출하여 전송 상태를 DELIVERED로 변경합니다. <br>
         """)
     @ApiErrorCodeExamples({
         ErrorCode.GIFTBOX_NOT_FOUND,

--- a/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
@@ -35,6 +35,7 @@ import com.dilly.gift.dto.response.GiftBoxesResponse;
 import com.dilly.gift.dto.response.GiftResponseDto.GiftResponse;
 import com.dilly.gift.dto.response.PhotoResponseDto.PhotoResponse;
 import com.dilly.gift.dto.response.StickerResponse;
+import com.dilly.gift.dto.response.WaitingGiftBoxResponse;
 import com.dilly.global.utils.SecurityUtil;
 import com.dilly.member.adaptor.MemberReader;
 import com.dilly.member.domain.Member;
@@ -294,5 +295,15 @@ public class GiftBoxService {
         giftBox.updateDeliverStatus(deliverStatus);
 
         return "선물박스 전송 상태가 변경되었습니다";
+    }
+
+    public List<WaitingGiftBoxResponse> getWaitingGiftBoxes() {
+        Long memberId = SecurityUtil.getMemberId();
+        Member member = memberReader.findById(memberId);
+
+        return giftBoxReader.findTop6BySenderAndDeliverStatusOrderByCreatedAtDesc(
+                member, DeliverStatus.WAITING).stream()
+            .map(WaitingGiftBoxResponse::from)
+            .toList();
     }
 }

--- a/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
@@ -301,7 +301,7 @@ public class GiftBoxService {
         Long memberId = SecurityUtil.getMemberId();
         Member member = memberReader.findById(memberId);
 
-        return giftBoxReader.findTop6BySenderAndDeliverStatusOrderByCreatedAtDesc(
+        return giftBoxReader.findTop6BySenderAndDeliverStatusAndSenderDeletedOrderByCreatedAtDesc(
                 member, DeliverStatus.WAITING).stream()
             .map(WaitingGiftBoxResponse::from)
             .toList();

--- a/packy-api/src/main/java/com/dilly/gift/dto/response/GiftBoxesResponse.java
+++ b/packy-api/src/main/java/com/dilly/gift/dto/response/GiftBoxesResponse.java
@@ -19,7 +19,7 @@ public record GiftBoxesResponse(
     String receiver,
     @Schema(example = "최고의선물박스")
     String name,
-    @Schema(example = "2024-01-01T00:00:00")
+    @Schema(example = "2024-01-01T00:00:00.0000")
     LocalDateTime giftBoxDate,
     @Schema(example = "www.example.com")
     String boxNormal

--- a/packy-api/src/main/java/com/dilly/gift/dto/response/WaitingGiftBoxResponse.java
+++ b/packy-api/src/main/java/com/dilly/gift/dto/response/WaitingGiftBoxResponse.java
@@ -1,15 +1,21 @@
 package com.dilly.gift.dto.response;
 
 import com.dilly.gift.domain.giftbox.GiftBox;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.Builder;
 
 @Builder
 public record WaitingGiftBoxResponse(
+    @Schema(example = "1")
     Long id,
+    @Schema(example = "선물박스 이름")
     String name,
+    @Schema(example = "받는 사람 이름")
     String receiverName,
+    @Schema(example = "2024-01-01T00:00:00.0000")
     LocalDateTime createdAt,
+    @Schema(example = "www.example.com")
     String smallImgUrl
 ) {
 

--- a/packy-api/src/main/java/com/dilly/gift/dto/response/WaitingGiftBoxResponse.java
+++ b/packy-api/src/main/java/com/dilly/gift/dto/response/WaitingGiftBoxResponse.java
@@ -1,0 +1,25 @@
+package com.dilly.gift.dto.response;
+
+import com.dilly.gift.domain.giftbox.GiftBox;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record WaitingGiftBoxResponse(
+    Long id,
+    String name,
+    String receiverName,
+    LocalDateTime createdAt,
+    String smallImgUrl
+) {
+
+    public static WaitingGiftBoxResponse from(GiftBox giftBox) {
+        return WaitingGiftBoxResponse.builder()
+            .id(giftBox.getId())
+            .name(giftBox.getName())
+            .receiverName(giftBox.getReceiverName())
+            .createdAt(giftBox.getCreatedAt())
+            .smallImgUrl(giftBox.getBox().getSmallImgUrl())
+            .build();
+    }
+}

--- a/packy-api/src/test/java/com/dilly/gift/api/GiftBoxControllerTest.java
+++ b/packy-api/src/test/java/com/dilly/gift/api/GiftBoxControllerTest.java
@@ -22,13 +22,16 @@ import com.dilly.gift.dto.response.GiftBoxResponse;
 import com.dilly.gift.dto.response.GiftResponseDto.GiftResponse;
 import com.dilly.gift.dto.response.PhotoResponseDto.PhotoResponse;
 import com.dilly.gift.dto.response.StickerResponse;
+import com.dilly.gift.dto.response.WaitingGiftBoxResponse;
 import com.dilly.global.ControllerTestSupport;
 import com.dilly.global.WithCustomMockUser;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.springframework.http.MediaType;
 
@@ -230,5 +233,36 @@ class GiftBoxControllerTest extends ControllerTestSupport {
                         jsonPath("$.data.stickers", hasSize(giftBoxResponse.stickers().size())));
             })
         );
+    }
+
+    @DisplayName("보내지 않은 선물박스를 최신순으로 6개 조회한다.")
+    @Test
+    @WithCustomMockUser
+    void getWaitingGiftBoxes() throws Exception {
+        // given
+        List<WaitingGiftBoxResponse> waitingGiftBoxResponses = new ArrayList<>();
+
+        for (int i = 1; i <= 6; i++) {
+            waitingGiftBoxResponses.add(WaitingGiftBoxResponse.builder()
+                .id((long) i)
+                .name("test" + i)
+                .receiverName("receiver" + i)
+                .smallImgUrl("www.example.com")
+                .build());
+        }
+
+        given(giftBoxService.getWaitingGiftBoxes()).willReturn(waitingGiftBoxResponses);
+
+        // when // then
+        mockMvc.perform(
+                get(giftBoxBaseUrl + "/waiting")
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data").isArray())
+            .andExpect(jsonPath("$.data", hasSize(6)))
+            .andExpect(jsonPath("$.data[0].id").value(waitingGiftBoxResponses.get(0).id()))
+            .andExpect(jsonPath("$.data[5].id").value(waitingGiftBoxResponses.get(5).id()));
+
     }
 }

--- a/packy-api/src/test/java/com/dilly/gift/api/GiftBoxControllerTest.java
+++ b/packy-api/src/test/java/com/dilly/gift/api/GiftBoxControllerTest.java
@@ -163,8 +163,6 @@ class GiftBoxControllerTest extends ControllerTestSupport {
                 // when // then
                 mockMvc.perform(
                         get(giftBoxBaseUrl + "/{giftBoxId}", anyLong())
-                            .with(csrf())
-                            .contentType(MediaType.APPLICATION_JSON)
                     )
                     .andDo(print())
                     .andExpect(status().isOk())
@@ -208,8 +206,6 @@ class GiftBoxControllerTest extends ControllerTestSupport {
                 // when // then
                 mockMvc.perform(
                         get(giftBoxBaseUrl + "/{giftBoxId}", anyLong())
-                            .with(csrf())
-                            .contentType(MediaType.APPLICATION_JSON)
                     )
                     .andDo(print())
                     .andExpect(status().isOk())

--- a/packy-api/src/test/java/com/dilly/gift/application/GiftBoxServiceTest.java
+++ b/packy-api/src/test/java/com/dilly/gift/application/GiftBoxServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.dilly.exception.GiftBoxAlreadyOpenedException;
+import com.dilly.gift.domain.giftbox.DeliverStatus;
 import com.dilly.gift.domain.giftbox.GiftBox;
 import com.dilly.gift.domain.sticker.GiftBoxSticker;
 import com.dilly.gift.domain.giftbox.GiftBoxType;
@@ -165,7 +166,7 @@ class GiftBoxServiceTest extends IntegrationTestSupport {
             @WithCustomMockUser(id = "2")
             void openGiftBoxWithGift() {
                 // given
-                giftBoxWithGift = createMockGiftBoxWithGift(member1);
+                giftBoxWithGift = createMockGiftBoxWithGift(member1, DeliverStatus.DELIVERED);
                 Long receiverBefore = receiverRepository.countByGiftBox(giftBoxWithGift);
                 List<PhotoResponse> expectedPhotoResponses = photoRepository.findAllByGiftBox(
                         giftBoxWithGift).stream()
@@ -208,7 +209,7 @@ class GiftBoxServiceTest extends IntegrationTestSupport {
             @WithCustomMockUser(id = "2")
             void openGiftBoxWithoutGift() {
                 // given
-                giftBoxWithoutGift = createMockGiftBoxWithoutGift(member1);
+                giftBoxWithoutGift = createMockGiftBoxWithoutGift(member1, DeliverStatus.DELIVERED);
                 Long receiverBefore = receiverRepository.countByGiftBox(giftBoxWithoutGift);
                 List<PhotoResponse> expectedPhotoResponses = photoRepository.findAllByGiftBox(
                         giftBoxWithoutGift).stream()
@@ -251,7 +252,7 @@ class GiftBoxServiceTest extends IntegrationTestSupport {
         @DisplayName("이미 열린 선물박스일 경우")
         class ContextWithAlreadyOpenedGiftBox {
 
-            GiftBox giftBox = createMockGiftBoxWithGift(member1);
+            GiftBox giftBox = createMockGiftBoxWithGift(member1, DeliverStatus.DELIVERED);
 
             @Test
             @DisplayName("선물박스를 이전에 받은 사람은 다시 열 수 있다.")

--- a/packy-api/src/test/java/com/dilly/global/IntegrationTestSupport.java
+++ b/packy-api/src/test/java/com/dilly/global/IntegrationTestSupport.java
@@ -106,7 +106,7 @@ public abstract class IntegrationTestSupport {
     @Autowired
     protected SettingRepository settingRepository;
 
-    protected GiftBox createMockGiftBoxWithGift(Member member) {
+    protected GiftBox createMockGiftBoxWithGift(Member member, DeliverStatus deliverStatus) {
         Box box = boxRepository.findById(1L).orElseThrow();
         Envelope envelope = envelopeRepository.findById(1L).orElseThrow();
         Letter letter = letterRepository.save(Letter.of("test", envelope));
@@ -121,7 +121,7 @@ public abstract class IntegrationTestSupport {
             .youtubeUrl("www.youtube.com")
             .senderName("sender")
             .receiverName("receiver")
-            .deliverStatus(DeliverStatus.DELIVERED)
+            .deliverStatus(deliverStatus)
             .build());
 
         photoRepository.save(Photo.of(giftBox, "www.test.com", "test", 1));
@@ -133,7 +133,7 @@ public abstract class IntegrationTestSupport {
         return giftBox;
     }
 
-    protected GiftBox createMockGiftBoxWithoutGift(Member member) {
+    protected GiftBox createMockGiftBoxWithoutGift(Member member, DeliverStatus deliverStatus) {
         Box box = boxRepository.findById(1L).orElseThrow();
         Envelope envelope = envelopeRepository.findById(1L).orElseThrow();
         Letter letter = letterRepository.save(Letter.of("test", envelope));
@@ -146,7 +146,7 @@ public abstract class IntegrationTestSupport {
             .youtubeUrl("www.youtube.com")
             .senderName("sender")
             .receiverName("receiver")
-            .deliverStatus(DeliverStatus.DELIVERED)
+            .deliverStatus(deliverStatus)
             .build());
 
         photoRepository.save(Photo.of(giftBox, "www.test.com", "test", 1));

--- a/packy-domain/src/main/java/com/dilly/gift/adaptor/GiftBoxReader.java
+++ b/packy-domain/src/main/java/com/dilly/gift/adaptor/GiftBoxReader.java
@@ -32,7 +32,8 @@ public class GiftBoxReader {
         return giftBoxRepository.findByLetter(letter);
     }
 
-    public List<GiftBox> findTop6BySenderAndDeliverStatusOrderByCreatedAtDesc(Member member,
+    public List<GiftBox> findTop6BySenderAndDeliverStatusAndSenderDeletedOrderByCreatedAtDesc(
+        Member member,
         DeliverStatus deliverStatus) {
         return giftBoxRepository.findTop6BySenderAndDeliverStatusAndSenderDeletedOrderByCreatedAtDesc(
             member,

--- a/packy-domain/src/main/java/com/dilly/gift/adaptor/GiftBoxReader.java
+++ b/packy-domain/src/main/java/com/dilly/gift/adaptor/GiftBoxReader.java
@@ -4,11 +4,13 @@ import com.dilly.exception.ErrorCode;
 import com.dilly.exception.entitynotfound.EntityNotFoundException;
 import com.dilly.gift.dao.GiftBoxRepository;
 import com.dilly.gift.dao.querydsl.GiftBoxQueryRepository;
+import com.dilly.gift.domain.giftbox.DeliverStatus;
 import com.dilly.gift.domain.giftbox.GiftBox;
 import com.dilly.gift.domain.letter.Letter;
 import com.dilly.member.domain.Member;
 import java.time.LocalDateTime;
 import java.util.Comparator;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -28,6 +30,13 @@ public class GiftBoxReader {
 
     public GiftBox findByLetter(Letter letter) {
         return giftBoxRepository.findByLetter(letter);
+    }
+
+    public List<GiftBox> findTop6BySenderAndDeliverStatusOrderByCreatedAtDesc(Member member,
+        DeliverStatus deliverStatus) {
+        return giftBoxRepository.findTop6BySenderAndDeliverStatusAndSenderDeletedOrderByCreatedAtDesc(
+            member,
+            deliverStatus, false);
     }
 
     public Slice<GiftBox> searchSentGiftBoxesBySlice(Member member, LocalDateTime lastGiftBoxDate,

--- a/packy-domain/src/main/java/com/dilly/gift/dao/GiftBoxRepository.java
+++ b/packy-domain/src/main/java/com/dilly/gift/dao/GiftBoxRepository.java
@@ -1,7 +1,10 @@
 package com.dilly.gift.dao;
 
+import com.dilly.gift.domain.giftbox.DeliverStatus;
 import com.dilly.gift.domain.giftbox.GiftBox;
 import com.dilly.gift.domain.letter.Letter;
+import com.dilly.member.domain.Member;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GiftBoxRepository extends JpaRepository<GiftBox, Long> {
@@ -9,4 +12,8 @@ public interface GiftBoxRepository extends JpaRepository<GiftBox, Long> {
 	GiftBox findTopByOrderByIdDesc();
 
     GiftBox findByLetter(Letter letter);
+
+    List<GiftBox> findTop6BySenderAndDeliverStatusAndSenderDeletedOrderByCreatedAtDesc(
+        Member member,
+        DeliverStatus deliverStatus, Boolean senderDeleted);
 }


### PR DESCRIPTION
## 🛰️ Issue Number
#172 

## 🪐 작업 내용
- 보내지 않은 선물박스 조회 API를 구현하고, Controller 및 Service 테스트 코드를 작성하였습니다.
  - 보내지 않은 선물박스는 페이징 없이 최신순으로 최대 6개 조회할 수 있습니다.
  - 삭제된 선물박스는 조회되지 않습니다. (senderDeleted가 false인 경우만 조회)
- 기존 API Swagger Description에서 글머리 번호를 지우고 `<br>`을 사용하도록 수정하였습니다.
  - 글머리 번호 사용 시 텍스트가 작아지는 현상이 있었습니다.

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [ ] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
