### PR TITLE
feat: 패키의 선물박스 조회 API 구현

### DIFF
--- a/packy-api/src/main/java/com/dilly/admin/api/AdminController.java
+++ b/packy-api/src/main/java/com/dilly/admin/api/AdminController.java
@@ -9,6 +9,7 @@ import com.dilly.application.YoutubeService;
 import com.dilly.dto.response.StatusResponse;
 import com.dilly.exception.ErrorCode;
 import com.dilly.gift.dto.response.EnvelopeListResponse;
+import com.dilly.gift.dto.response.GiftBoxResponse;
 import com.dilly.global.response.DataResponseDto;
 import com.dilly.global.response.SliceResponseDto;
 import com.dilly.global.swagger.ApiErrorCodeExample;
@@ -22,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -104,5 +106,15 @@ public class AdminController {
     @GetMapping("/settings")
     public DataResponseDto<List<SettingResponse>> getSettingUrls() {
         return DataResponseDto.from(adminService.getSettingUrls());
+    }
+
+    @Operation(summary = "패키의 선물박스 조회")
+    @GetMapping("/giftboxes/{screenType}")
+    public DataResponseDto<GiftBoxResponse> getPackyGiftBox(
+        @PathVariable("screenType")
+        @Schema(description = "사용하는 화면", type = "string", allowableValues = {"onboarding"})
+        String screenType
+    ) {
+        return DataResponseDto.from(adminService.getPackyGiftBox(screenType));
     }
 }

--- a/packy-api/src/main/java/com/dilly/admin/application/AdminService.java
+++ b/packy-api/src/main/java/com/dilly/admin/application/AdminService.java
@@ -1,22 +1,36 @@
 package com.dilly.admin.application;
 
+import com.dilly.admin.adaptor.AdminGiftBoxReader;
 import com.dilly.admin.adaptor.SettingReader;
+import com.dilly.admin.domain.giftbox.ScreenType;
+import com.dilly.admin.domain.music.Music;
 import com.dilly.admin.domain.setting.Setting;
 import com.dilly.admin.dto.response.BoxImgResponse;
 import com.dilly.admin.dto.response.ImgResponse;
 import com.dilly.admin.dto.response.MusicResponse;
 import com.dilly.admin.dto.response.SettingResponse;
+import com.dilly.exception.ErrorCode;
+import com.dilly.exception.UnsupportedException;
 import com.dilly.gift.adaptor.BoxReader;
 import com.dilly.gift.adaptor.EnvelopeReader;
+import com.dilly.gift.adaptor.GiftBoxStickerReader;
 import com.dilly.gift.adaptor.MusicReader;
+import com.dilly.gift.adaptor.PhotoReader;
 import com.dilly.gift.adaptor.StickerReader;
 import com.dilly.gift.domain.Box;
+import com.dilly.gift.domain.giftbox.GiftBox;
 import com.dilly.gift.domain.letter.Envelope;
-import com.dilly.admin.domain.music.Music;
 import com.dilly.gift.domain.sticker.Sticker;
+import com.dilly.gift.dto.response.BoxResponse;
 import com.dilly.gift.dto.response.EnvelopeListResponse;
+import com.dilly.gift.dto.response.EnvelopeResponse;
+import com.dilly.gift.dto.response.GiftBoxResponse;
+import com.dilly.gift.dto.response.GiftResponseDto.GiftResponse;
+import com.dilly.gift.dto.response.PhotoResponseDto.PhotoResponse;
+import com.dilly.gift.dto.response.StickerResponse;
 import com.dilly.member.adaptor.ProfileImageReader;
 import com.dilly.member.domain.ProfileImage;
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,6 +52,9 @@ public class AdminService {
     private final MusicReader musicReader;
     private final StickerReader stickerReader;
     private final SettingReader settingReader;
+    private final AdminGiftBoxReader adminGiftBoxReader;
+    private final PhotoReader photoReader;
+    private final GiftBoxStickerReader giftBoxStickerReader;
 
     public List<ImgResponse> getProfiles() {
         List<ProfileImage> profileImages = profileImageReader.findAllByOrderBySequenceAsc();
@@ -80,5 +97,36 @@ public class AdminService {
         List<Setting> settingUrls = settingReader.findAll();
 
         return settingUrls.stream().map(SettingResponse::from).toList();
+    }
+
+    public GiftBoxResponse getPackyGiftBox(String screenType) {
+        ScreenType type;
+        try {
+            type = ScreenType.valueOf(screenType);
+        } catch (IllegalArgumentException e) {
+            throw new UnsupportedException(ErrorCode.UNSUPPORTED_SCREEN_TYPE);
+        }
+
+        GiftBox giftBox = adminGiftBoxReader.findByScreenType(type).getGiftBox();
+
+        BoxResponse boxResponse = BoxResponse.from(giftBox.getBox());
+        EnvelopeResponse envelopeResponse = EnvelopeResponse.from(
+            giftBox.getLetter().getEnvelope());
+        List<PhotoResponse> photos = photoReader.findAllByGiftBox(giftBox).stream()
+            .map(PhotoResponse::from)
+            .sorted(Comparator.comparingInt(PhotoResponse::sequence))
+            .toList();
+        List<StickerResponse> stickers = giftBoxStickerReader.findAllByGiftBox(giftBox).stream()
+            .map(StickerResponse::from)
+            .sorted(Comparator.comparingInt(StickerResponse::location))
+            .toList();
+
+        GiftResponse giftResponse = null;
+        if (giftBox.getGift() != null) {
+            giftResponse = GiftResponse.from(giftBox.getGift());
+        }
+
+        return GiftBoxResponse.of(giftBox, boxResponse, envelopeResponse, photos, stickers,
+            giftResponse);
     }
 }

--- a/packy-api/src/main/java/com/dilly/admin/application/AdminService.java
+++ b/packy-api/src/main/java/com/dilly/admin/application/AdminService.java
@@ -102,7 +102,7 @@ public class AdminService {
     public GiftBoxResponse getPackyGiftBox(String screenType) {
         ScreenType type;
         try {
-            type = ScreenType.valueOf(screenType);
+            type = ScreenType.valueOf(screenType.toUpperCase());
         } catch (IllegalArgumentException e) {
             throw new UnsupportedException(ErrorCode.UNSUPPORTED_SCREEN_TYPE);
         }

--- a/packy-api/src/main/java/com/dilly/auth/application/AuthService.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/AuthService.java
@@ -4,6 +4,8 @@ import static com.dilly.member.domain.Provider.APPLE;
 import static com.dilly.member.domain.Provider.KAKAO;
 import static com.dilly.member.domain.Provider.TEST;
 
+import com.dilly.admin.adaptor.AdminGiftBoxReader;
+import com.dilly.admin.domain.giftbox.ScreenType;
 import com.dilly.auth.adaptor.AppleAccountReader;
 import com.dilly.auth.adaptor.AppleAccountWriter;
 import com.dilly.auth.adaptor.KakaoAccountReader;
@@ -17,6 +19,8 @@ import com.dilly.auth.model.AppleToken;
 import com.dilly.auth.model.KakaoResource;
 import com.dilly.exception.ErrorCode;
 import com.dilly.exception.UnsupportedException;
+import com.dilly.gift.adaptor.ReceiverWriter;
+import com.dilly.gift.domain.giftbox.GiftBox;
 import com.dilly.global.utils.SecurityUtil;
 import com.dilly.jwt.JwtService;
 import com.dilly.jwt.RefreshToken;
@@ -54,6 +58,8 @@ public class AuthService {
 	private final AppleAccountWriter appleAccountWriter;
 	private final JwtReader jwtReader;
 	private final JwtWriter jwtWriter;
+	private final AdminGiftBoxReader adminGiftBoxReader;
+	private final ReceiverWriter receiverWriter;
 
 	public JwtResponse signUp(String providerAccessToken, SignupRequest signupRequest) {
 		Provider provider;
@@ -92,6 +98,10 @@ public class AuthService {
 
 			default -> throw new UnsupportedException(ErrorCode.UNSUPPORTED_LOGIN_TYPE);
 		}
+
+		GiftBox onboardingGiftBox = adminGiftBoxReader.findByScreenType(ScreenType.ONBOARDING)
+			.getGiftBox();
+		receiverWriter.save(member, onboardingGiftBox);
 
 		return jwtService.issueJwt(member);
 	}

--- a/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
@@ -21,6 +21,7 @@ import com.dilly.gift.domain.gift.GiftType;
 import com.dilly.gift.domain.giftbox.DeliverStatus;
 import com.dilly.gift.domain.giftbox.GiftBox;
 import com.dilly.gift.domain.giftbox.GiftBoxRole;
+import com.dilly.gift.domain.giftbox.GiftBoxType;
 import com.dilly.gift.domain.letter.Envelope;
 import com.dilly.gift.domain.letter.Letter;
 import com.dilly.gift.domain.receiver.Receiver;
@@ -107,11 +108,14 @@ public class GiftBoxService {
             giftBox.getBox().getKakaoMessageImgUrl());
     }
 
+    // TODO: 가독성 개선하기
     void checkIfGiftBoxOpenable(Member member, GiftBox giftBox) {
+        // 카카오톡으로 보내기를 누르지 않은 선물박스
         if (giftBox.getDeliverStatus().equals(DeliverStatus.WAITING)) {
             throw new GiftBoxAccessDeniedException();
         }
 
+        // 선물박스를 만든 유저가 삭제했을 경우, 만든 유저가 선물박스에 접근 불가능
         if (giftBox.getSender().equals(member)) {
             if (giftBox.getSenderDeleted().equals(true)) {
                 throw new GiftBoxAccessDeniedException();
@@ -122,18 +126,23 @@ public class GiftBoxService {
                 .map(Member::getId)
                 .toList();
 
+            // 선물박스를 받기 전이며 만든 유저가 삭제하지 않았을 경우
             if (receivers.isEmpty() && giftBox.getSenderDeleted().equals(false)) {
                 receiverWriter.save(member, giftBox);
                 return;
             }
 
+            // 이전에 선물박스를 받았던 유저인 경우
             if (receivers.contains(member.getId())) {
                 Receiver receiver = receiverReader.findByMemberAndGiftBox(member, giftBox);
+                // 받은 사람이 삭제했을 경우
                 if (receiver.getStatus().equals(ReceiverStatus.DELETED)) {
                     throw new GiftBoxAccessDeniedException();
                 }
-            } else {
-                throw new GiftBoxAlreadyOpenedException();
+            } else { // 이전에 선물박스를 받지 않은 유저인 경우
+                if (giftBox.getGiftBoxType().equals(GiftBoxType.PRIVATE)) {
+                    throw new GiftBoxAlreadyOpenedException();
+                }
             }
         }
     }

--- a/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
@@ -145,8 +145,9 @@ public class GiftBoxService {
 
         checkIfGiftBoxOpenable(member, giftBox);
 
-        BoxResponse boxResponse = BoxResponse.of(giftBox.getBox());
-        EnvelopeResponse envelopeResponse = EnvelopeResponse.of(giftBox.getLetter().getEnvelope());
+        BoxResponse boxResponse = BoxResponse.from(giftBox.getBox());
+        EnvelopeResponse envelopeResponse = EnvelopeResponse.from(
+            giftBox.getLetter().getEnvelope());
         List<PhotoResponse> photos = photoReader.findAllByGiftBox(giftBox).stream()
             .map(PhotoResponse::from)
             .sorted(Comparator.comparingInt(PhotoResponse::sequence))

--- a/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
@@ -152,7 +152,7 @@ public class GiftBoxService {
             .sorted(Comparator.comparingInt(PhotoResponse::sequence))
             .toList();
         List<StickerResponse> stickers = giftBoxStickerReader.findAllByGiftBox(giftBox).stream()
-            .map(StickerResponse::of)
+            .map(StickerResponse::from)
             .sorted(Comparator.comparingInt(StickerResponse::location))
             .toList();
 

--- a/packy-api/src/main/java/com/dilly/gift/dto/response/BoxResponse.java
+++ b/packy-api/src/main/java/com/dilly/gift/dto/response/BoxResponse.java
@@ -15,7 +15,7 @@ public record BoxResponse(
     String boxTop
 ) {
 
-    public static BoxResponse of(Box box) {
+    public static BoxResponse from(Box box) {
         return BoxResponse.builder()
             .id(box.getId())
             .boxNormal(box.getNormalImgUrl())

--- a/packy-api/src/main/java/com/dilly/gift/dto/response/EnvelopeResponse.java
+++ b/packy-api/src/main/java/com/dilly/gift/dto/response/EnvelopeResponse.java
@@ -14,7 +14,7 @@ public record EnvelopeResponse(
     Integer opacity
 ) {
 
-    public static EnvelopeResponse of(Envelope envelope) {
+    public static EnvelopeResponse from(Envelope envelope) {
         return EnvelopeResponse.builder()
             .imgUrl(envelope.getImgUrl())
             .borderColorCode(envelope.getLetterPaper().getLetterBorderColorCode())

--- a/packy-api/src/main/java/com/dilly/gift/dto/response/LetterResponse.java
+++ b/packy-api/src/main/java/com/dilly/gift/dto/response/LetterResponse.java
@@ -17,7 +17,7 @@ public record LetterResponse(
         return LetterResponse.builder()
             .id(letter.getId())
             .letterContent(letter.getContent())
-            .envelope(EnvelopeResponse.of(letter.getEnvelope()))
+            .envelope(EnvelopeResponse.from(letter.getEnvelope()))
             .build();
     }
 }

--- a/packy-api/src/main/java/com/dilly/gift/dto/response/StickerResponse.java
+++ b/packy-api/src/main/java/com/dilly/gift/dto/response/StickerResponse.java
@@ -9,7 +9,7 @@ public record StickerResponse(
     Integer location
 ) {
 
-    public static StickerResponse of(GiftBoxSticker giftBoxSticker) {
+    public static StickerResponse from(GiftBoxSticker giftBoxSticker) {
         return StickerResponse.builder()
             .imgUrl(giftBoxSticker.getSticker().getImgUrl())
             .location(giftBoxSticker.getLocation())

--- a/packy-api/src/test/java/com/dilly/gift/application/GiftBoxServiceTest.java
+++ b/packy-api/src/test/java/com/dilly/gift/application/GiftBoxServiceTest.java
@@ -155,7 +155,7 @@ class GiftBoxServiceTest extends IntegrationTestSupport {
 
         GiftBox giftBoxWithGift;
         GiftBox giftBoxWithoutGift;
-        BoxResponse expectedBoxResponse = BoxResponse.of(
+        BoxResponse expectedBoxResponse = BoxResponse.from(
             boxRepository.findById(1L).orElseThrow());
 
         @Nested
@@ -176,7 +176,7 @@ class GiftBoxServiceTest extends IntegrationTestSupport {
                     .toList();
                 List<StickerResponse> expectedStickerResponses = giftBoxStickerRepository.findAllByGiftBox(
                         giftBoxWithGift).stream()
-                    .map(StickerResponse::of)
+                    .map(StickerResponse::from)
                     .sorted(Comparator.comparingInt(StickerResponse::location))
                     .toList();
                 GiftResponse expectedGiftResponse = GiftResponse.from(giftBoxWithGift.getGift());
@@ -219,7 +219,7 @@ class GiftBoxServiceTest extends IntegrationTestSupport {
                     .toList();
                 List<StickerResponse> expectedStickerResponses = giftBoxStickerRepository.findAllByGiftBox(
                         giftBoxWithoutGift).stream()
-                    .map(StickerResponse::of)
+                    .map(StickerResponse::from)
                     .sorted(Comparator.comparingInt(StickerResponse::location))
                     .toList();
 
@@ -269,7 +269,7 @@ class GiftBoxServiceTest extends IntegrationTestSupport {
                     .toList();
                 List<StickerResponse> expectedStickerResponses = giftBoxStickerRepository.findAllByGiftBox(
                         giftBox).stream()
-                    .map(StickerResponse::of)
+                    .map(StickerResponse::from)
                     .sorted(Comparator.comparingInt(StickerResponse::location))
                     .toList();
                 GiftResponse expectedGiftResponse = GiftResponse.from(giftBox.getGift());

--- a/packy-common/src/main/java/com/dilly/exception/ErrorCode.java
+++ b/packy-common/src/main/java/com/dilly/exception/ErrorCode.java
@@ -58,6 +58,7 @@ public enum ErrorCode {
     UNSUPPORTED_LOGIN_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 로그인 타입입니다."),
     UNSUPPORTED_GIFTBOX_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 선물박스 조회 타입입니다."),
     UNSUPPORTED_DELIVER_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 선물박스 전송 타입입니다."),
+    UNSUPPORTED_SCREEN_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 화면 타입입니다."),
 
     // Member
     MEMBER_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 가입된 유저입니다."),

--- a/packy-domain/src/main/java/com/dilly/admin/adaptor/AdminGiftBoxReader.java
+++ b/packy-domain/src/main/java/com/dilly/admin/adaptor/AdminGiftBoxReader.java
@@ -1,0 +1,18 @@
+package com.dilly.admin.adaptor;
+
+import com.dilly.admin.domain.giftbox.ScreenType;
+import com.dilly.gift.dao.AdminGiftBoxRepository;
+import com.dilly.gift.domain.giftbox.AdminGiftBox;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AdminGiftBoxReader {
+
+    private final AdminGiftBoxRepository adminGiftBoxRepository;
+
+    public AdminGiftBox findByScreenType(ScreenType screenType) {
+        return adminGiftBoxRepository.findByScreenType(screenType);
+    }
+}

--- a/packy-domain/src/main/java/com/dilly/admin/domain/giftbox/ScreenType.java
+++ b/packy-domain/src/main/java/com/dilly/admin/domain/giftbox/ScreenType.java
@@ -1,0 +1,5 @@
+package com.dilly.admin.domain.giftbox;
+
+public enum ScreenType {
+    ONBOARDING
+}

--- a/packy-domain/src/main/java/com/dilly/gift/dao/AdminGiftBoxRepository.java
+++ b/packy-domain/src/main/java/com/dilly/gift/dao/AdminGiftBoxRepository.java
@@ -1,0 +1,10 @@
+package com.dilly.gift.dao;
+
+import com.dilly.admin.domain.giftbox.ScreenType;
+import com.dilly.gift.domain.giftbox.AdminGiftBox;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminGiftBoxRepository extends JpaRepository<AdminGiftBox, Long> {
+
+    AdminGiftBox findByScreenType(ScreenType screenType);
+}

--- a/packy-domain/src/main/java/com/dilly/gift/domain/giftbox/AdminGiftBox.java
+++ b/packy-domain/src/main/java/com/dilly/gift/domain/giftbox/AdminGiftBox.java
@@ -1,0 +1,29 @@
+package com.dilly.gift.domain.giftbox;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import com.dilly.admin.domain.giftbox.ScreenType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class AdminGiftBox {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private ScreenType screenType;
+
+    @OneToOne
+    @JoinColumn(name = "gift_box_id")
+    private GiftBox giftBox;
+}

--- a/packy-domain/src/main/java/com/dilly/gift/domain/giftbox/GiftBox.java
+++ b/packy-domain/src/main/java/com/dilly/gift/domain/giftbox/GiftBox.java
@@ -19,6 +19,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -78,6 +79,9 @@ public class GiftBox extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Builder.Default
     private DeliverStatus deliverStatus = DeliverStatus.WAITING;
+
+    @OneToOne(mappedBy = "giftBox")
+    private AdminGiftBox adminGiftBox;
 
     public void delete() {
         this.senderDeleted = true;

--- a/packy-domain/src/main/resources/db/migration/V30__add_deliver_status_in_gift_box.sql
+++ b/packy-domain/src/main/resources/db/migration/V30__add_deliver_status_in_gift_box.sql
@@ -5,4 +5,4 @@ add column deliver_status enum('WAITING', 'DELIVERED') not null default 'WAITING
 -- 기존에 만들어진 박스는 DELIVERED 처리
 update gift_box
 set deliver_status = 'DELIVERED'
-where created_at < NOW();
+where created_at < '2024-02-24 00:00:00';

--- a/packy-domain/src/main/resources/db/migration/V31__add_admin_gift_box_table.sql
+++ b/packy-domain/src/main/resources/db/migration/V31__add_admin_gift_box_table.sql
@@ -1,0 +1,5 @@
+-- admin_gift_box 테이블 생성
+create table admin_gift_box (gift_box_id bigint, id bigint not null auto_increment, screen_type enum ('ONBOARDING'), primary key (id));
+
+alter table admin_gift_box add constraint UK_ch8i00c0ry5pmqba9wfjygo7b unique (gift_box_id);
+alter table admin_gift_box add constraint FKrqscgkmmi1tdameg7ecnogr35 foreign key (gift_box_id) references gift_box (id);


### PR DESCRIPTION
## 🛰️ Issue Number
#179

## 🪐 작업 내용
- 패키의 선물박스 조회 API를 구현하였습니다. bb5227bc857ab94f669462c58207d56745a064dc
  - 현재는 온보딩 화면에서 주는 선물박스 하나지만, 추후 시즈너블/이벤트성 패키의 선물박스가 생길 것을 고려하여 screenType enum 클래스를 만들고 다양한 패키의 선물박스를 만들 수 있도록 구현하였습니다.
  - 처음에 유저의 선물박스와 패키의 선물박스 테이블을 분리할까 고민하였지만, 구성 요소가 일치하기 때문에 관리 포인트를 줄이기 위해 하나의 테이블에 저장하도록 했습니다.
    - adminGiftBox 엔티티를 만들어 패키의 선물박스를 구분하고, 패키의 선물박스의 용도를 저장합니다.
  - 패키의 선물박스의 경우, `ROLE_ADMIN` 역할을 가진 패키 공식 계정 유저가 만든 선물박스를 의미합니다.
- 회원가입 시 receiver 테이블에 선물박스를 받았다는 정보를 저장하는 로직을 추가하였습니다.  a32fb372472e58081c839f97e359fe8e9e879512
- 기능 업데이트 이전에 설치한 유저들을 고려하여 받은 선물박스에서 온보딩 화면에서 받는 선물박스가 받은 선물박스의 최하단에 위치하도록 쿼리 메소드를 수정하였습니다. d8d5e328f5f0184fd734275641a5de290a570193
- flyway 스크립트에서 기능 업데이트 이전에 만들어진 선물박스의 deliverStatus를 DELIVERED로 바꿀 때, 조건을 NOW() 이전으로 할 경우 NOW()의 시각이 불명확하므로 데모데이 이전을 명시적으로 날짜를 기입하였습니다.

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [ ] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
