### PR TITLE
fix: 선물박스를 만든 사람은 보내지 않은 선물박스를 열 수 있도록 선물박스 열기 API 수정

### DIFF
--- a/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
+++ b/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
@@ -64,7 +64,8 @@ public class GiftBoxController {
     @ApiErrorCodeExamples({
         ErrorCode.GIFTBOX_NOT_FOUND,
         ErrorCode.GIFTBOX_ALREADY_OPENDED,
-        ErrorCode.GIFTBOX_ACCESS_DENIED
+        ErrorCode.GIFTBOX_ACCESS_DENIED,
+        ErrorCode.GIFTBOX_ALREADY_DELETED
     })
     @GetMapping("/{giftBoxId}")
     public DataResponseDto<GiftBoxResponse> openGiftBox(

--- a/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
@@ -2,6 +2,7 @@ package com.dilly.gift.application;
 
 import com.dilly.exception.ErrorCode;
 import com.dilly.exception.GiftBoxAccessDeniedException;
+import com.dilly.exception.GiftBoxAlreadyDeletedException;
 import com.dilly.exception.GiftBoxAlreadyOpenedException;
 import com.dilly.exception.UnsupportedException;
 import com.dilly.gift.adaptor.BoxReader;
@@ -111,7 +112,9 @@ public class GiftBoxService {
     // TODO: 가독성 개선하기
     void checkIfGiftBoxOpenable(Member member, GiftBox giftBox) {
         // 카카오톡으로 보내기를 누르지 않은 선물박스
-        if (giftBox.getDeliverStatus().equals(DeliverStatus.WAITING)) {
+        // 만든 유저는 선물박스에 접근 가능
+        if (giftBox.getDeliverStatus().equals(DeliverStatus.WAITING) && (!giftBox.getSender()
+            .equals(member))) {
             throw new GiftBoxAccessDeniedException();
         }
 

--- a/packy-common/src/main/java/com/dilly/exception/ErrorCode.java
+++ b/packy-common/src/main/java/com/dilly/exception/ErrorCode.java
@@ -68,6 +68,7 @@ public enum ErrorCode {
     ENVELOPE_NOT_FOUND(HttpStatus.NOT_FOUND, "편지 봉투를 찾을 수 없습니다."),
     GIFTBOX_ALREADY_OPENDED(HttpStatus.CONFLICT, "이미 열린 선물입니다."),
     GIFTBOX_ACCESS_DENIED(HttpStatus.FORBIDDEN, "선물박스에 접근할 수 없습니다."),
+    GIFTBOX_ALREADY_DELETED(HttpStatus.NOT_FOUND, "이미 삭제된 선물박스입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/packy-common/src/main/java/com/dilly/exception/GiftBoxAlreadyDeletedException.java
+++ b/packy-common/src/main/java/com/dilly/exception/GiftBoxAlreadyDeletedException.java
@@ -1,0 +1,8 @@
+package com.dilly.exception;
+
+public class GiftBoxAlreadyDeletedException extends BusinessException {
+
+    public GiftBoxAlreadyDeletedException() {
+        super(ErrorCode.GIFTBOX_ALREADY_DELETED);
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
#181 

## 🪐 작업 내용
- DeliverStatus가 WAITING이며 유저가 선물박스를 만든 사람이 아닐 경우 GiftBoxAlreadyDeletedException을 던지도록 checkIfGiftBoxOpenable 메서드를 수정하였습니다. d2798aa7e4649e63dd42edcd087b936059657a5b

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
