### PR TITLE
feat: giftBoxId로 카카오톡 메시지 이미지 조회 API 구현

### DIFF
--- a/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
+++ b/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
@@ -7,9 +7,11 @@ import com.dilly.gift.dto.request.GiftBoxRequest;
 import com.dilly.gift.dto.response.GiftBoxIdResponse;
 import com.dilly.gift.dto.response.GiftBoxResponse;
 import com.dilly.gift.dto.response.GiftBoxesResponse;
+import com.dilly.gift.dto.response.KakaoImgResponse;
 import com.dilly.gift.dto.response.WaitingGiftBoxResponse;
 import com.dilly.global.response.DataResponseDto;
 import com.dilly.global.response.SliceResponseDto;
+import com.dilly.global.swagger.ApiErrorCodeExample;
 import com.dilly.global.swagger.ApiErrorCodeExamples;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -131,5 +133,14 @@ public class GiftBoxController {
     @GetMapping("/waiting")
     public DataResponseDto<List<WaitingGiftBoxResponse>> getWaitingGiftBoxes() {
         return DataResponseDto.from(giftBoxService.getWaitingGiftBoxes());
+    }
+
+    @Operation(summary = "선물박스 ID로 카카오톡 메시지 이미지 조회")
+    @ApiErrorCodeExample(ErrorCode.GIFTBOX_NOT_FOUND)
+    @GetMapping("/{giftBoxId}/kakao-image")
+    public DataResponseDto<KakaoImgResponse> getKakaoMessageImgUrl(
+        @PathVariable("giftBoxId") Long giftBoxId
+    ) {
+        return DataResponseDto.from(giftBoxService.getKakaoMessageImgUrl(giftBoxId));
     }
 }

--- a/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
@@ -35,6 +35,7 @@ import com.dilly.gift.dto.response.GiftBoxIdResponse;
 import com.dilly.gift.dto.response.GiftBoxResponse;
 import com.dilly.gift.dto.response.GiftBoxesResponse;
 import com.dilly.gift.dto.response.GiftResponseDto.GiftResponse;
+import com.dilly.gift.dto.response.KakaoImgResponse;
 import com.dilly.gift.dto.response.PhotoResponseDto.PhotoResponse;
 import com.dilly.gift.dto.response.StickerResponse;
 import com.dilly.gift.dto.response.WaitingGiftBoxResponse;
@@ -320,5 +321,10 @@ public class GiftBoxService {
                 member, DeliverStatus.WAITING).stream()
             .map(WaitingGiftBoxResponse::from)
             .toList();
+    }
+
+    public KakaoImgResponse getKakaoMessageImgUrl(Long giftBoxId) {
+        GiftBox giftBox = giftBoxReader.findById(giftBoxId);
+        return KakaoImgResponse.from(giftBox.getBox().getKakaoMessageImgUrl());
     }
 }

--- a/packy-api/src/main/java/com/dilly/gift/dto/response/KakaoImgResponse.java
+++ b/packy-api/src/main/java/com/dilly/gift/dto/response/KakaoImgResponse.java
@@ -1,0 +1,17 @@
+package com.dilly.gift.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record KakaoImgResponse(
+    @Schema(example = "www.example.com")
+    String kakaoMessageImgUrl
+) {
+
+        public static KakaoImgResponse from(String kakaoMessageImgUrl) {
+            return KakaoImgResponse.builder()
+                .kakaoMessageImgUrl(kakaoMessageImgUrl)
+                .build();
+        }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
#183

## 🪐 작업 내용
giftBoxId를 요청값으로 받아 카카오톡 메시지 이미지를 응답값으로 반환하는 API를 구현하였습니다.

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [ ] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
