### PR TITLE
fix: 심사를 올리기 전까지는 홈 화면에 패키의 선물박스가 뜨지 않도록 변경

### DIFF
--- a/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
+++ b/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
@@ -145,7 +145,7 @@ public class GiftBoxController {
         return DataResponseDto.from(giftBoxService.getKakaoMessageImgUrl(giftBoxId));
     }
 
-    @Operation(summary = "메인화면에 띄울 선물박스 조회")
+    @Operation(summary = "홈 화면에 띄울 선물박스 조회")
     @GetMapping("/main")
     public DataResponseDto<MainGiftBoxResponse> getMainGiftBox() {
         return DataResponseDto.from(giftBoxService.getMainGiftBox());

--- a/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
@@ -338,10 +338,12 @@ public class GiftBoxService {
         Optional<AdminGiftBox> adminGiftBox = adminGiftBoxReader.findByAdminType(
             AdminType.ONBOARDING);
 
-        if (adminGiftBox.isPresent()) {
-            return MainGiftBoxResponse.from(adminGiftBox.get().getGiftBox());
-        } else {
-            return MainGiftBoxResponse.builder().build();
-        }
+//        if (adminGiftBox.isPresent()) {
+//            return MainGiftBoxResponse.from(adminGiftBox.get().getGiftBox());
+//        } else {
+//            return MainGiftBoxResponse.builder().build();
+//        }
+
+        return MainGiftBoxResponse.builder().build();
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
#188

## 🪐 작업 내용
- 유저 당 한 번씩 뜨는 로직을 완성하기 전까지는 패키의 선물박스가 홈 화면에 뜨지 않도록 임시 수정했습니다.

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [ ] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
