### PR TITLE
fix: 보낸 선물박스를 giftBox의 updatedAt을 기준으로 정렬

### DIFF
--- a/packy-api/src/main/java/com/dilly/gift/dto/response/GiftBoxesResponse.java
+++ b/packy-api/src/main/java/com/dilly/gift/dto/response/GiftBoxesResponse.java
@@ -32,7 +32,7 @@ public record GiftBoxesResponse(
             .sender(giftBox.getSenderName())
             .receiver(giftBox.getReceiverName())
             .name(giftBox.getName())
-            .giftBoxDate(giftBox.getCreatedAt())
+            .giftBoxDate(giftBox.getUpdatedAt())
             .boxNormal(giftBox.getBox().getNormalImgUrl())
             .build();
     }

--- a/packy-domain/src/main/java/com/dilly/gift/dao/querydsl/GiftBoxQueryRepository.java
+++ b/packy-domain/src/main/java/com/dilly/gift/dao/querydsl/GiftBoxQueryRepository.java
@@ -1,16 +1,13 @@
 package com.dilly.gift.dao.querydsl;
 
 import static com.dilly.gift.domain.giftbox.QGiftBox.giftBox;
-import static com.dilly.gift.domain.giftbox.admin.QAdminGiftBox.adminGiftBox;
 import static com.dilly.gift.domain.receiver.QReceiver.receiver;
 
 import com.dilly.gift.domain.giftbox.DeliverStatus;
 import com.dilly.gift.domain.giftbox.GiftBox;
-import com.dilly.gift.domain.giftbox.admin.AdminType;
 import com.dilly.gift.domain.receiver.ReceiverStatus;
 import com.dilly.member.domain.Member;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -95,15 +92,11 @@ public class GiftBoxQueryRepository {
         return jpaQueryFactory.select(giftBox)
             .from(receiver)
             .join(receiver.giftBox, giftBox)
-            .leftJoin(giftBox.adminGiftBox, adminGiftBox)
             .where(
                 ltReceivedDate(lastGiftBoxDate),
                 receiver.member.eq(member),
                 receiver.status.eq(ReceiverStatus.RECEIVED))
             .orderBy(
-                new CaseBuilder()
-                    .when(adminGiftBox.adminType.eq(AdminType.ONBOARDING)).then(1)
-                    .otherwise(0).asc(),
                 receiver.createdAt.desc()
             )
             .limit(pageable.getPageSize() + 1L)

--- a/packy-domain/src/main/java/com/dilly/gift/dao/querydsl/GiftBoxQueryRepository.java
+++ b/packy-domain/src/main/java/com/dilly/gift/dao/querydsl/GiftBoxQueryRepository.java
@@ -82,7 +82,7 @@ public class GiftBoxQueryRepository {
                 giftBox.sender.eq(member),
                 giftBox.senderDeleted.eq(false),
                 giftBox.deliverStatus.eq(DeliverStatus.DELIVERED))
-            .orderBy(giftBox.createdAt.desc())
+            .orderBy(giftBox.updatedAt.desc())
             .limit(pageable.getPageSize() + 1L)
             .fetch();
     }
@@ -108,7 +108,7 @@ public class GiftBoxQueryRepository {
             return null;
         }
 
-        return giftBox.createdAt.lt(giftBoxDate);
+        return giftBox.updatedAt.lt(giftBoxDate);
     }
 
     private BooleanExpression ltReceivedDate(LocalDateTime giftBoxDate) {

--- a/packy-domain/src/main/java/com/dilly/gift/domain/giftbox/GiftBox.java
+++ b/packy-domain/src/main/java/com/dilly/gift/domain/giftbox/GiftBox.java
@@ -5,7 +5,6 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 import com.dilly.gift.domain.Box;
 import com.dilly.gift.domain.Photo;
 import com.dilly.gift.domain.gift.Gift;
-import com.dilly.gift.domain.giftbox.admin.AdminGiftBox;
 import com.dilly.gift.domain.letter.Letter;
 import com.dilly.gift.domain.sticker.GiftBoxSticker;
 import com.dilly.global.BaseTimeEntity;
@@ -20,7 +19,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -80,9 +78,6 @@ public class GiftBox extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Builder.Default
     private DeliverStatus deliverStatus = DeliverStatus.WAITING;
-
-    @OneToOne(mappedBy = "giftBox")
-    private AdminGiftBox adminGiftBox;
 
     public void delete() {
         this.senderDeleted = true;


### PR DESCRIPTION
## 🛰️ Issue Number
#196 

## 🪐 작업 내용
- GiftBoxesResponse DTO의 giftBoxDate를 giftBox의 updatedAt으로 변경하였습니다.
- getSentGiftBoxes 메서드의 정렬 조건을 giftBox의 updatedAt으로 변경하였습니다.
- 업데이트 이전에 설치한 유저들이 패키의 선물박스를 받은 날짜를 회원가입일로 수정하며, 받은 선물박스에서 온보딩 선물박스인지 여부가 필요하지 않게 되었습니다. (무조건 최하단에 위치하기 때문) 이에 따라 사용하지 않는 정렬 조건과 조인 조건 코드를 제거하였습니다. 

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
