### PR TITLE
refactor: 나중에 보내는 선물박스를 삭제할 경우 S3에서 이미지 파일 삭제

### DIFF
--- a/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
+++ b/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
@@ -103,7 +103,8 @@ public class GiftBoxController {
     @Operation(summary = "선물박스 삭제")
     @ApiErrorCodeExamples({
         ErrorCode.GIFTBOX_NOT_FOUND,
-        ErrorCode.GIFTBOX_ACCESS_DENIED
+        ErrorCode.GIFTBOX_ACCESS_DENIED,
+        ErrorCode.FILE_DELETE_ERROR
     })
     @DeleteMapping("/{giftBoxId}")
     public DataResponseDto<String> deleteGiftBox(

--- a/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
@@ -289,9 +289,10 @@ public class GiftBoxService {
                     fileService.deleteFile(photo.getImgUrl());
                     photoWriter.delete(photo);
                 });
+                if (giftBox.getGift().getGiftType().equals(GiftType.PHOTO)) {
+                    fileService.deleteFile(giftBox.getGift().getGiftUrl());
+                }
                 giftBox.getGiftBoxStickers().forEach(giftBoxStickerWriter::delete);
-                giftBox.getReceivers().forEach(Receiver::delete);
-
                 giftBoxWriter.delete(giftBox);
             }
         } else if (role.equals(GiftBoxRole.RECEIVER)) {

--- a/packy-common/src/main/java/com/dilly/exception/ErrorCode.java
+++ b/packy-common/src/main/java/com/dilly/exception/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
 
     // File
     FILE_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파일 서버 연동에 오류가 발생했습니다."),
+    FILE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제에 실패했습니다."),
 
     // Authorization
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),

--- a/packy-domain/src/main/java/com/dilly/gift/adaptor/GiftBoxStickerWriter.java
+++ b/packy-domain/src/main/java/com/dilly/gift/adaptor/GiftBoxStickerWriter.java
@@ -18,4 +18,8 @@ public class GiftBoxStickerWriter {
         Sticker sticker = stickerReader.findById(stickerId);
         giftBoxStickerRepository.save(GiftBoxSticker.of(giftBox, sticker, stickerLocation));
     }
+
+    public void delete(GiftBoxSticker giftBoxSticker) {
+        giftBoxStickerRepository.delete(giftBoxSticker);
+    }
 }

--- a/packy-domain/src/main/java/com/dilly/gift/adaptor/GiftBoxWriter.java
+++ b/packy-domain/src/main/java/com/dilly/gift/adaptor/GiftBoxWriter.java
@@ -44,4 +44,8 @@ public class GiftBoxWriter {
 			.receiverName(receiverName)
 			.build());
 	}
+
+	public void delete(GiftBox giftBox) {
+		giftBoxRepository.delete(giftBox);
+	}
 }

--- a/packy-domain/src/main/java/com/dilly/gift/adaptor/LetterWriter.java
+++ b/packy-domain/src/main/java/com/dilly/gift/adaptor/LetterWriter.java
@@ -15,4 +15,8 @@ public class LetterWriter {
 	public Letter save(String content, Envelope envelope) {
 		return letterRepository.save(Letter.of(content, envelope));
 	}
+
+	public void delete(Letter letter) {
+		letterRepository.delete(letter);
+	}
 }

--- a/packy-domain/src/main/java/com/dilly/gift/adaptor/PhotoWriter.java
+++ b/packy-domain/src/main/java/com/dilly/gift/adaptor/PhotoWriter.java
@@ -1,8 +1,8 @@
 package com.dilly.gift.adaptor;
 
 import com.dilly.gift.dao.PhotoRepository;
-import com.dilly.gift.domain.giftbox.GiftBox;
 import com.dilly.gift.domain.Photo;
+import com.dilly.gift.domain.giftbox.GiftBox;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -14,5 +14,9 @@ public class PhotoWriter {
 
 	public void save(GiftBox giftBox, String photoUrl, String description, Integer sequence) {
 		photoRepository.save(Photo.of(giftBox, photoUrl, description, sequence));
+	}
+
+	public void delete(Photo photo) {
+		photoRepository.delete(photo);
 	}
 }

--- a/packy-domain/src/main/java/com/dilly/gift/adaptor/ReceiverWriter.java
+++ b/packy-domain/src/main/java/com/dilly/gift/adaptor/ReceiverWriter.java
@@ -16,4 +16,8 @@ public class ReceiverWriter {
     public void save(Member member, GiftBox giftBox) {
         receiverRepository.save(Receiver.of(member, giftBox));
     }
+
+    public void delete(Receiver receiver) {
+        receiverRepository.delete(receiver);
+    }
 }

--- a/packy-domain/src/main/java/com/dilly/gift/domain/giftbox/GiftBox.java
+++ b/packy-domain/src/main/java/com/dilly/gift/domain/giftbox/GiftBox.java
@@ -6,6 +6,7 @@ import com.dilly.gift.domain.Box;
 import com.dilly.gift.domain.Photo;
 import com.dilly.gift.domain.gift.Gift;
 import com.dilly.gift.domain.letter.Letter;
+import com.dilly.gift.domain.receiver.Receiver;
 import com.dilly.gift.domain.sticker.GiftBoxSticker;
 import com.dilly.global.BaseTimeEntity;
 import com.dilly.member.domain.Member;
@@ -78,6 +79,10 @@ public class GiftBox extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Builder.Default
     private DeliverStatus deliverStatus = DeliverStatus.WAITING;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "giftBox")
+    private List<Receiver> receivers = new ArrayList<>();
 
     public void delete() {
         this.senderDeleted = true;

--- a/packy-infra/src/main/java/com/dilly/application/FileService.java
+++ b/packy-infra/src/main/java/com/dilly/application/FileService.java
@@ -24,6 +24,9 @@ public class FileService {
 	@Value("${cloud.s3.bucket}")
 	private String bucket;
 
+	@Value("${cloud.aws.region}")
+	private String region;
+
 	private final AmazonS3 amazonS3;
 
 	public FileRequest getPresignedUrl(String prefix, String fileName) {
@@ -37,6 +40,20 @@ public class FileService {
 		return FileRequest.builder()
 			.url(url.toString())
 			.build();
+	}
+
+	public void deleteFile(String imgUrl) {
+		try {
+			String prefix = "https://" + bucket + ".s3." + region + ".amazonaws.com/";
+			String keyName = imgUrl.replace(prefix, "");
+			boolean isObjectExist = amazonS3.doesObjectExist(bucket, keyName);
+
+			if (isObjectExist) {
+				amazonS3.deleteObject(bucket, keyName);
+			}
+		} catch (Exception e) {
+			throw new InternalServerException(ErrorCode.FILE_DELETE_ERROR);
+		}
 	}
 
 	private GeneratePresignedUrlRequest getGeneratePresignedUrlRequest(String bucket, String fileName) {


### PR DESCRIPTION
## 🛰️ Issue Number
#197 

## 🪐 작업 내용
- S3 파일 삭제 메서드를 구현하였습니다.
- 보내지 않은 선물박스를 삭제 시 S3에서 이미지 파일을 삭제 및 DB에 저장된 데이터를 hard delete하도록 선물박스 삭제 API 코드를 수정하였습니다.

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [ ] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
