### PR TITLE
fix: 회원가입 및 로그인 API 응답값에 id값 추가

### DIFF
--- a/packy-api/src/main/java/com/dilly/jwt/TokenProvider.java
+++ b/packy-api/src/main/java/com/dilly/jwt/TokenProvider.java
@@ -63,6 +63,7 @@ public class TokenProvider {
 			.compact();
 
 		return JwtResponse.builder()
+			.id(member.getId())
 			.grantType(BEARER_TYPE)
 			.accessToken(accessToken)
 			.refreshToken(refreshToken)

--- a/packy-api/src/main/java/com/dilly/jwt/dto/JwtResponse.java
+++ b/packy-api/src/main/java/com/dilly/jwt/dto/JwtResponse.java
@@ -1,13 +1,14 @@
 package com.dilly.jwt.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record JwtResponse(
+	@Schema(example = "1")
+	Long id,
 	@Schema(example = "Bearer")
 	String grantType,
 	@Schema(example = "eyJhbGciOiJIUzUxMiJ9...")

--- a/packy-domain/build.gradle
+++ b/packy-domain/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     // database
-    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.mysql:mysql-connector-j:8.0.35'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // logging

--- a/packy-domain/build.gradle
+++ b/packy-domain/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     // database
-    runtimeOnly 'com.mysql:mysql-connector-j:8.0.35'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // logging


### PR DESCRIPTION
## 🛰️ Issue Number
#203

## 🪐 작업 내용
- 회원가입 및 로그인 API 응답값에 id값을 추가하였습니다. d9edbac
- `java.lang.IllegalStateException: Cannot load driver class: com.mysql.cj.jdbc.Driver`라는 에러가 발생하여 mysql-connector-j의 버전을 RDS에서 사용하는 MySQL 버전으로 명시하여 해결하였습니다. 26075c4
## 📚 Reference
- https://jiny-dev.tistory.com/27

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
