### PR TITLE
fix: 앱 사용 가능 상태 확인 API에서 major 버전만 비교하도록 변경

### DIFF
--- a/packy-api/src/main/java/com/dilly/member/api/MemberController.java
+++ b/packy-api/src/main/java/com/dilly/member/api/MemberController.java
@@ -24,8 +24,8 @@ public class MemberController {
         , description = "reason: NEED_UPDATE(업데이트 필요), INVALID_STATUS(탈퇴, 정지 등 올바르지 않은 유저 상태)")
     @GetMapping("/status")
     public DataResponseDto<StatusResponse> getStatus(
-        @RequestParam("app-version") @Schema(example = "1.0.0") String appVersion
+        @RequestParam("app-version") @Schema(example = "1") Integer memberMajorVersion
     ) {
-        return DataResponseDto.from(memberService.getStatus(appVersion));
+        return DataResponseDto.from(memberService.getStatus(memberMajorVersion));
     }
 }

--- a/packy-api/src/main/java/com/dilly/member/application/MemberService.java
+++ b/packy-api/src/main/java/com/dilly/member/application/MemberService.java
@@ -1,6 +1,6 @@
 package com.dilly.member.application;
 
-import static com.dilly.global.Constants.LATEST_VERSION;
+import static com.dilly.global.Constants.LATEST_MAJOR_VERSION;
 
 import com.dilly.global.util.SecurityUtil;
 import com.dilly.member.adaptor.MemberReader;
@@ -21,7 +21,7 @@ public class MemberService {
 
     private final MemberReader memberReader;
 
-    public StatusResponse getStatus(String appVersion) {
+    public StatusResponse getStatus(Integer memberMajorVersion) {
         Long memberId = SecurityUtil.getMemberId();
         Member member = memberReader.findById(memberId);
 
@@ -31,23 +31,10 @@ public class MemberService {
         }
 
         // 유저 버전 확인
-        Integer latestMajorVersion = getMajorVersion(LATEST_VERSION);
-        Integer memberMajorVersion = getMajorVersion(appVersion);
-        log.info("latestMajorVersion: {}, userMajorVersion: {}", latestMajorVersion, memberMajorVersion);
-
-        if (memberMajorVersion < latestMajorVersion) {
+        if (memberMajorVersion < LATEST_MAJOR_VERSION) {
             return StatusResponse.from(false, Reason.NEED_UPDATE);
         }
 
         return StatusResponse.from(true);
-    }
-
-    private Integer getMajorVersion(String version) {
-        String[] parts = version.split("\\.");
-        if (parts.length > 0) {
-            return Integer.parseInt(parts[0]);
-        } else {
-            return 0;
-        }
     }
 }

--- a/packy-domain/src/main/java/com/dilly/global/Constants.java
+++ b/packy-domain/src/main/java/com/dilly/global/Constants.java
@@ -3,5 +3,5 @@ package com.dilly.global;
 public class Constants {
     private Constants() {}
 
-    public static final String LATEST_VERSION = "1.1.1";
+    public static final Integer LATEST_MAJOR_VERSION = 1;
 }


### PR DESCRIPTION
## 🛰️ Issue Number
#201 

## 🪐 작업 내용
- 앱 사용 가능 상태 확인 API에서 시맨틱 버전 중 major 버전만 비교하도록 코드를 수정하였습니다.

## 📚 Reference

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
