### PR TITLE
fix: 앱 사용 가능 상태 확인 API minor 버전 비교 및 응답값에 memberId 추가

### DIFF
--- a/packy-api/src/main/java/com/dilly/member/dto/response/StatusResponse.java
+++ b/packy-api/src/main/java/com/dilly/member/dto/response/StatusResponse.java
@@ -8,6 +8,9 @@ import lombok.Builder;
 @Builder
 @JsonInclude(Include.NON_NULL)
 public record StatusResponse(
+    @Schema(example = "1")
+    Long id,
+
     @Schema(example = "true")
     Boolean isAvailable,
 
@@ -15,14 +18,16 @@ public record StatusResponse(
     Reason reason
 ) {
 
-    public static StatusResponse from(Boolean isAvailable) {
+    public static StatusResponse from(Long id, Boolean isAvailable) {
         return StatusResponse.builder()
+            .id(id)
             .isAvailable(isAvailable)
             .build();
     }
 
-    public static StatusResponse from(Boolean isAvailable, Reason reason) {
+    public static StatusResponse from(Long id, Boolean isAvailable, Reason reason) {
         return StatusResponse.builder()
+            .id(id)
             .isAvailable(isAvailable)
             .reason(reason)
             .build();

--- a/packy-common/src/main/java/com/dilly/exception/BadRequestException.java
+++ b/packy-common/src/main/java/com/dilly/exception/BadRequestException.java
@@ -1,0 +1,8 @@
+package com.dilly.exception;
+
+public class BadRequestException extends BusinessException {
+
+    public BadRequestException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/packy-common/src/main/java/com/dilly/exception/ErrorCode.java
+++ b/packy-common/src/main/java/com/dilly/exception/ErrorCode.java
@@ -70,6 +70,10 @@ public enum ErrorCode {
     GIFTBOX_ALREADY_OPENDED(HttpStatus.CONFLICT, "이미 열린 선물입니다."),
     GIFTBOX_ACCESS_DENIED(HttpStatus.FORBIDDEN, "선물박스에 접근할 수 없습니다."),
     GIFTBOX_ALREADY_DELETED(HttpStatus.NOT_FOUND, "이미 삭제된 선물박스입니다."),
+
+    // Version
+    FAILED_TO_EXTRACT_VERSION(HttpStatus.BAD_REQUEST, "사용자 버전을 추출하는데 실패했습니다."),
+    INVALID_LATEST_VERSION(HttpStatus.INTERNAL_SERVER_ERROR, "최신 버전이 올바르지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/packy-domain/src/main/java/com/dilly/global/Constants.java
+++ b/packy-domain/src/main/java/com/dilly/global/Constants.java
@@ -3,5 +3,5 @@ package com.dilly.global;
 public class Constants {
     private Constants() {}
 
-    public static final String LATEST_VERSION = "1.1.1";
+    public static final String MINIMUM_REQUIRED_VERSION = "1.1.1";
 }


### PR DESCRIPTION
## 🛰️ Issue Number
#204 

## 🪐 작업 내용
- 앱 사용 가능 상태 확인 API에 유저의 id를 추가하였습니다.
- 시맨틱 버전 비교 시 minor 버전을 비교하는 코드를 추가하였습니다. (참고: https://github.com/Central-MakeUs/Packy-Server/pull/205#issuecomment-2031035505)

## 📚 Reference
X

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
