### PR TITLE
fix: 회원 정보가 없는 경우 tokenInfo 생략

### DIFF
--- a/packy-api/src/main/java/com/dilly/auth/application/AuthService.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/AuthService.java
@@ -130,8 +130,7 @@ public class AuthService {
 
 		SignInResponse signInResponse;
 		if (member.isEmpty()) {
-			signInResponse = SignInResponse.from(Status.NOT_REGISTERED,
-				JwtResponse.builder().build());
+			signInResponse = SignInResponse.from(Status.NOT_REGISTERED);
 		} else {
 			signInResponse = SignInResponse.from(member.get().getStatus(),
 				member.get().getNickname(),

--- a/packy-api/src/main/java/com/dilly/auth/dto/response/SignInResponse.java
+++ b/packy-api/src/main/java/com/dilly/auth/dto/response/SignInResponse.java
@@ -16,10 +16,9 @@ public record SignInResponse(
 	JwtResponse tokenInfo
 ) {
 
-	public static SignInResponse from(Status status, JwtResponse tokenInfo) {
+	public static SignInResponse from(Status status) {
 		return SignInResponse.builder()
 			.status(status)
-			.tokenInfo(tokenInfo)
 			.build();
 	}
 


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
- 회원 정보가 없는 경우 tokenInfo를 빈 객체로 보내어 로그인 API 연동 오류가 발생하였습니다. 클라이언트 개발자의 요청에 따라 회원 정보가 없는 경우 응답값에서 tokenInfo를 생략했습니다.

## 📚 Reference

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
